### PR TITLE
test: add coverage for Inngest pipeline functions

### DIFF
--- a/packages/pipeline/__tests__/auto-merge.test.ts
+++ b/packages/pipeline/__tests__/auto-merge.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { inngest } from '../src/inngest.js';
+
+const mockPullsGet = vi.fn();
+const mockPullsListReviews = vi.fn();
+const mockMergePR = vi.fn();
+
+vi.mock('../src/inngest.js', () => ({
+  inngest: {
+    createFunction: vi.fn((_config: unknown, _trigger: unknown, handler: unknown) => handler),
+    send: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../src/github.js', () => ({
+  getOctokit: vi.fn(() => ({
+    pulls: {
+      get: mockPullsGet,
+      listReviews: mockPullsListReviews,
+    },
+  })),
+  parseRepo: vi.fn((repo: string) => {
+    const [owner, name] = repo.split('/');
+    return { owner, repo: name };
+  }),
+  mergePR: mockMergePR,
+}));
+
+type StepRun = (name: string, fn: () => Promise<unknown>) => Promise<unknown>;
+
+const createMockStep = () => ({
+  run: vi.fn<Parameters<StepRun>, ReturnType<StepRun>>().mockImplementation((_name, fn) => fn()),
+});
+
+const BASE_EVENT = {
+  data: { prNumber: 10, branch: 'canductor/issue-1', repo: 'acme/repo', passed: true },
+};
+
+describe('autoMerge function', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let handler: (ctx: { event: unknown; step: ReturnType<typeof createMockStep> }) => Promise<any>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import('../src/functions/auto-merge.js');
+    handler = mod.autoMerge as typeof handler;
+    mockMergePR.mockResolvedValue(undefined);
+  });
+
+  it('returns skipped when passed=false', async () => {
+    const mockStep = createMockStep();
+    const result = await handler({
+      event: { data: { prNumber: 10, branch: 'canductor/issue-1', repo: 'acme/repo', passed: false } },
+      step: mockStep,
+    });
+
+    expect(result).toEqual({ status: 'skipped' });
+    expect(mockStep.run).not.toHaveBeenCalled();
+  });
+
+  it('returns skipped when prNumber is missing', async () => {
+    const mockStep = createMockStep();
+    const result = await handler({
+      event: { data: { branch: 'canductor/issue-1', repo: 'acme/repo', passed: true } },
+      step: mockStep,
+    });
+
+    expect(result).toEqual({ status: 'skipped' });
+    expect(mockStep.run).not.toHaveBeenCalled();
+  });
+
+  it('returns not_ready when PR is not open', async () => {
+    mockPullsGet.mockResolvedValue({ data: { state: 'closed', mergeable: null, user: { login: 'bot' } } });
+    mockPullsListReviews.mockResolvedValue({ data: [] });
+    const mockStep = createMockStep();
+
+    const result = await handler({ event: BASE_EVENT, step: mockStep });
+
+    expect(result).toEqual({ status: 'not_ready', prNumber: 10 });
+    expect(mockMergePR).not.toHaveBeenCalled();
+  });
+
+  it('returns not_ready when PR is not mergeable', async () => {
+    mockPullsGet.mockResolvedValue({ data: { state: 'open', mergeable: false, user: { login: 'bot' } } });
+    mockPullsListReviews.mockResolvedValue({ data: [] });
+    const mockStep = createMockStep();
+
+    const result = await handler({ event: BASE_EVENT, step: mockStep });
+
+    expect(result).toEqual({ status: 'not_ready', prNumber: 10 });
+    expect(mockMergePR).not.toHaveBeenCalled();
+  });
+
+  it('returns not_ready when no approvals and PR is not from owner', async () => {
+    mockPullsGet.mockResolvedValue({
+      data: { state: 'open', mergeable: true, user: { login: 'contributor' } },
+    });
+    mockPullsListReviews.mockResolvedValue({ data: [] });
+    const mockStep = createMockStep();
+
+    const result = await handler({ event: BASE_EVENT, step: mockStep });
+
+    expect(result).toEqual({ status: 'not_ready', prNumber: 10 });
+  });
+
+  it('merges PR when approved and triggers next story', async () => {
+    mockPullsGet.mockResolvedValue({
+      data: { state: 'open', mergeable: true, user: { login: 'bot' } },
+    });
+    mockPullsListReviews.mockResolvedValue({ data: [{ state: 'APPROVED' }] });
+    const mockStep = createMockStep();
+
+    const result = await handler({ event: BASE_EVENT, step: mockStep });
+
+    expect(result).toEqual({ status: 'merged', prNumber: 10 });
+    expect(mockMergePR).toHaveBeenCalledWith('acme/repo', 10, 'squash');
+    expect(vi.mocked(inngest.send)).toHaveBeenCalledWith({
+      name: 'canductor/story.completed',
+      data: { issueNumber: 0, repo: 'acme/repo' },
+    });
+  });
+});

--- a/packages/pipeline/__tests__/implement.test.ts
+++ b/packages/pipeline/__tests__/implement.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock inngest so createFunction returns the raw handler
+vi.mock('../src/inngest.js', () => ({
+  inngest: {
+    createFunction: vi.fn((_config: unknown, _trigger: unknown, handler: unknown) => handler),
+    send: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+const mockGetIssue = vi.fn();
+const mockGetDefaultBranchSha = vi.fn();
+const mockCreateBranch = vi.fn();
+const mockDispatchWorkflow = vi.fn();
+const mockCommentOnIssue = vi.fn();
+
+vi.mock('../src/github.js', () => ({
+  getIssue: mockGetIssue,
+  getDefaultBranchSha: mockGetDefaultBranchSha,
+  createBranch: mockCreateBranch,
+  dispatchWorkflow: mockDispatchWorkflow,
+  commentOnIssue: mockCommentOnIssue,
+}));
+
+type StepRun = (name: string, fn: () => Promise<unknown>) => Promise<unknown>;
+type StepWait = (name: string, opts: unknown) => Promise<unknown>;
+
+const createMockStep = () => ({
+  run: vi.fn<Parameters<StepRun>, ReturnType<StepRun>>().mockImplementation((_name, fn) => fn()),
+  waitForEvent: vi.fn<Parameters<StepWait>, ReturnType<StepWait>>(),
+});
+
+describe('implement function', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let handler: (ctx: { event: unknown; step: ReturnType<typeof createMockStep> }) => Promise<any>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import('../src/functions/implement.js');
+    handler = mod.implement as typeof handler;
+    mockGetIssue.mockResolvedValue({ title: 'Fix thing', body: 'Do the thing' });
+    mockGetDefaultBranchSha.mockResolvedValue('abc123');
+    mockCreateBranch.mockResolvedValue(undefined);
+    mockDispatchWorkflow.mockResolvedValue(undefined);
+    mockCommentOnIssue.mockResolvedValue(undefined);
+  });
+
+  it('dispatches agent, waits for verify event, returns implemented status', async () => {
+    const mockStep = createMockStep();
+    mockStep.waitForEvent.mockResolvedValue({
+      data: { branch: 'canductor/issue-7', repo: 'acme/repo' },
+    });
+
+    const result = await handler({
+      event: { data: { issueNumber: 7, repo: 'acme/repo', agent: 'claude-code' } },
+      step: mockStep,
+    });
+
+    expect(result).toEqual({ status: 'implemented', branch: 'canductor/issue-7', issueNumber: 7 });
+
+    expect(mockGetIssue).toHaveBeenCalledWith('acme/repo', 7);
+    expect(mockGetDefaultBranchSha).toHaveBeenCalledWith('acme/repo');
+    expect(mockCreateBranch).toHaveBeenCalledWith('acme/repo', 'canductor/issue-7', 'abc123');
+    expect(mockDispatchWorkflow).toHaveBeenCalledWith('acme/repo', 'agent.yml', {
+      issue_number: '7',
+      branch: 'canductor/issue-7',
+      prompt: 'Implement this issue:\n\nTitle: Fix thing\n\nDo the thing',
+    });
+    expect(mockCommentOnIssue).toHaveBeenCalledWith(
+      'acme/repo',
+      7,
+      'Implementation started on branch `canductor/issue-7`. Agent: claude-code'
+    );
+    expect(mockStep.waitForEvent).toHaveBeenCalledWith('wait-for-agent', {
+      event: 'canductor/verify.requested',
+      match: 'data.branch',
+      timeout: '90m',
+    });
+  });
+
+  it('handles timeout: comments and returns timeout status', async () => {
+    const mockStep = createMockStep();
+    mockStep.waitForEvent.mockResolvedValue(null);
+
+    const result = await handler({
+      event: { data: { issueNumber: 7, repo: 'acme/repo' } },
+      step: mockStep,
+    });
+
+    expect(result).toEqual({ status: 'timeout', branch: 'canductor/issue-7' });
+    expect(mockCommentOnIssue).toHaveBeenLastCalledWith(
+      'acme/repo',
+      7,
+      'Agent timed out after 90 minutes on branch `canductor/issue-7`.'
+    );
+  });
+
+  it('uses default agent name when agent not provided', async () => {
+    const mockStep = createMockStep();
+    mockStep.waitForEvent.mockResolvedValue({ data: {} });
+
+    await handler({
+      event: { data: { issueNumber: 3, repo: 'acme/repo' } },
+      step: mockStep,
+    });
+
+    expect(mockCommentOnIssue).toHaveBeenCalledWith(
+      'acme/repo',
+      3,
+      'Implementation started on branch `canductor/issue-3`. Agent: claude-code'
+    );
+  });
+});

--- a/packages/pipeline/__tests__/orchestrate.test.ts
+++ b/packages/pipeline/__tests__/orchestrate.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { inngest } from '../src/inngest.js';
+
+const mockListForRepo = vi.fn();
+
+vi.mock('../src/inngest.js', () => ({
+  inngest: {
+    createFunction: vi.fn((_config: unknown, _trigger: unknown, handler: unknown) => handler),
+    send: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../src/github.js', () => ({
+  getOctokit: vi.fn(() => ({
+    issues: {
+      listForRepo: mockListForRepo,
+    },
+  })),
+  parseRepo: vi.fn((repo: string) => {
+    const [owner, name] = repo.split('/');
+    return { owner, repo: name };
+  }),
+}));
+
+type StepRun = (name: string, fn: () => Promise<unknown>) => Promise<unknown>;
+
+const createMockStep = () => ({
+  run: vi.fn<Parameters<StepRun>, ReturnType<StepRun>>().mockImplementation((_name, fn) => fn()),
+});
+
+const BASE_EVENT = { data: { issueNumber: 5, repo: 'acme/repo' } };
+
+describe('orchestrate function', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let handler: (ctx: { event: unknown; step: ReturnType<typeof createMockStep> }) => Promise<any>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import('../src/functions/orchestrate.js');
+    handler = mod.orchestrate as typeof handler;
+  });
+
+  it('returns no_more_stories when no pending issues exist', async () => {
+    mockListForRepo.mockResolvedValue({ data: [] });
+    const mockStep = createMockStep();
+
+    const result = await handler({ event: BASE_EVENT, step: mockStep });
+
+    expect(result).toEqual({ status: 'no_more_stories' });
+    expect(mockListForRepo).toHaveBeenCalledWith({
+      owner: 'acme',
+      repo: 'repo',
+      labels: 'story,pending',
+      state: 'open',
+      sort: 'created',
+      direction: 'asc',
+      per_page: 1,
+    });
+    expect(vi.mocked(inngest.send)).not.toHaveBeenCalled();
+  });
+
+  it('triggers implementation for the next pending story', async () => {
+    mockListForRepo.mockResolvedValue({ data: [{ number: 42, title: 'Next story' }] });
+    const mockStep = createMockStep();
+
+    const result = await handler({ event: BASE_EVENT, step: mockStep });
+
+    expect(result).toEqual({ status: 'triggered', nextIssue: 42 });
+    expect(vi.mocked(inngest.send)).toHaveBeenCalledWith({
+      name: 'canductor/issue.assigned',
+      data: { issueNumber: 42, repo: 'acme/repo' },
+    });
+  });
+
+  it('queries oldest first to maintain story order', async () => {
+    mockListForRepo.mockResolvedValue({ data: [] });
+    const mockStep = createMockStep();
+
+    await handler({ event: BASE_EVENT, step: mockStep });
+
+    expect(mockListForRepo).toHaveBeenCalledWith(
+      expect.objectContaining({ sort: 'created', direction: 'asc' })
+    );
+  });
+});

--- a/packages/pipeline/__tests__/verify-and-fix.test.ts
+++ b/packages/pipeline/__tests__/verify-and-fix.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/inngest.js', () => ({
+  inngest: {
+    createFunction: vi.fn((_config: unknown, _trigger: unknown, handler: unknown) => handler),
+    send: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+const mockDispatchWorkflow = vi.fn();
+const mockCreatePR = vi.fn();
+const mockCommentOnIssue = vi.fn();
+
+vi.mock('../src/github.js', () => ({
+  dispatchWorkflow: mockDispatchWorkflow,
+  createPR: mockCreatePR,
+  commentOnIssue: mockCommentOnIssue,
+}));
+
+type StepRun = (name: string, fn: () => Promise<unknown>) => Promise<unknown>;
+type StepWait = (name: string, opts: unknown) => Promise<unknown>;
+
+const createMockStep = () => ({
+  run: vi.fn<Parameters<StepRun>, ReturnType<StepRun>>().mockImplementation((_name, fn) => fn()),
+  waitForEvent: vi.fn<Parameters<StepWait>, ReturnType<StepWait>>(),
+});
+
+const BASE_EVENT = {
+  data: { branch: 'canductor/issue-1', repo: 'acme/repo', issueNumber: 1 },
+};
+
+describe('verifyAndFix function', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let handler: (ctx: { event: unknown; step: ReturnType<typeof createMockStep> }) => Promise<any>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import('../src/functions/verify-and-fix.js');
+    handler = mod.verifyAndFix as typeof handler;
+    mockDispatchWorkflow.mockResolvedValue(undefined);
+    mockCreatePR.mockResolvedValue(42);
+    mockCommentOnIssue.mockResolvedValue(undefined);
+  });
+
+  it('returns verified on first attempt when CI passes', async () => {
+    const mockStep = createMockStep();
+    mockStep.waitForEvent.mockResolvedValue({
+      data: { branch: 'canductor/issue-1', repo: 'acme/repo', passed: true },
+    });
+
+    const result = await handler({ event: BASE_EVENT, step: mockStep });
+
+    expect(result).toEqual({ status: 'verified', branch: 'canductor/issue-1', attempt: 0, prNumber: 42 });
+    expect(mockDispatchWorkflow).toHaveBeenCalledWith('acme/repo', 'verify.yml', {
+      branch: 'canductor/issue-1',
+      issue_number: '1',
+    });
+    expect(mockCreatePR).toHaveBeenCalledWith(
+      'acme/repo',
+      'canductor/issue-1',
+      'master',
+      'Implement #1',
+      'Closes #1\n\nAutonomously implemented by canductor.'
+    );
+  });
+
+  it('retries after failure and returns verified on second attempt', async () => {
+    const mockStep = createMockStep();
+    mockStep.waitForEvent
+      .mockResolvedValueOnce({ data: { branch: 'canductor/issue-1', repo: 'acme/repo', passed: false } })
+      .mockResolvedValueOnce({ data: { branch: 'canductor/issue-1', repo: 'acme/repo' } }) // wait-fix-1
+      .mockResolvedValueOnce({ data: { branch: 'canductor/issue-1', repo: 'acme/repo', passed: true } }); // wait-ci-1
+
+    const result = await handler({ event: BASE_EVENT, step: mockStep });
+
+    expect(result).toEqual({ status: 'verified', branch: 'canductor/issue-1', attempt: 1, prNumber: 42 });
+    expect(mockDispatchWorkflow).toHaveBeenCalledTimes(3); // verify-0, fix-1, verify-1
+    expect(mockDispatchWorkflow).toHaveBeenNthCalledWith(2, 'acme/repo', 'agent.yml', {
+      issue_number: '1',
+      branch: 'canductor/issue-1',
+      prompt: 'Fix attempt 1/6. The verification failed. Fix the errors and push to the branch.',
+    });
+  });
+
+  it('gives up after max attempts and posts failure comment', async () => {
+    const mockStep = createMockStep();
+    // Alternate: CI fail, fix wait (× 5 rounds), then final CI fail
+    mockStep.waitForEvent.mockImplementation(async (name: string) => {
+      if ((name as string).startsWith('wait-ci-')) {
+        return { data: { branch: 'canductor/issue-1', repo: 'acme/repo', passed: false } };
+      }
+      // fix waits
+      return { data: { branch: 'canductor/issue-1', repo: 'acme/repo' } };
+    });
+
+    const result = await handler({ event: BASE_EVENT, step: mockStep });
+
+    expect(result).toEqual({ status: 'failed', branch: 'canductor/issue-1', attempts: 6 });
+    expect(mockCommentOnIssue).toHaveBeenCalledWith(
+      'acme/repo',
+      1,
+      'Verification failed after 6 attempts on branch `canductor/issue-1`.'
+    );
+  });
+
+  it('breaks out and returns failed when CI times out (null result)', async () => {
+    const mockStep = createMockStep();
+    mockStep.waitForEvent.mockResolvedValue(null);
+
+    const result = await handler({ event: BASE_EVENT, step: mockStep });
+
+    expect(result).toEqual({ status: 'failed', branch: 'canductor/issue-1', attempts: 0 });
+  });
+});


### PR DESCRIPTION
## Summary

Adds test coverage for all 4 Inngest pipeline functions with mocked step functions and GitHub API.

Closes #3

Autonomously implemented by canductor's first agent run.

🤖 Generated with [Claude Code](https://claude.ai/code)