### PR TITLE
feat: build review relay — bot review → agent fix → re-verify

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,3 +86,10 @@ pnpm typecheck      # Type check all packages
 - **TSV for results**: Committed to repo, no external database needed
 - **Rubric-based evaluation**: Quality criteria defined in markdown, evaluated by LLM
 - **GitHub Actions only for agent execution**: claude-code-action requires GH Actions; everything else runs in Inngest
+
+<!-- canductor:start -->
+## Canductor Quality Context
+
+Current baseline quality score: 0/100
+
+<!-- canductor:end -->

--- a/packages/pipeline/__tests__/review-relay.test.ts
+++ b/packages/pipeline/__tests__/review-relay.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/inngest.js', () => ({
+  inngest: {
+    createFunction: vi.fn((_config: unknown, _trigger: unknown, handler: unknown) => handler),
+    send: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+const mockDispatchWorkflow = vi.fn();
+const mockCommentOnIssue = vi.fn();
+const mockGetPRReviewComments = vi.fn();
+
+vi.mock('../src/github.js', () => ({
+  dispatchWorkflow: mockDispatchWorkflow,
+  commentOnIssue: mockCommentOnIssue,
+  getPRReviewComments: mockGetPRReviewComments,
+}));
+
+type StepRun = (name: string, fn: () => Promise<unknown>) => Promise<unknown>;
+type StepWait = (name: string, opts: unknown) => Promise<unknown>;
+
+const createMockStep = () => ({
+  run: vi.fn<Parameters<StepRun>, ReturnType<StepRun>>().mockImplementation((_name, fn) => fn()),
+  waitForEvent: vi.fn<Parameters<StepWait>, ReturnType<StepWait>>(),
+});
+
+const BASE_EVENT = {
+  data: {
+    prNumber: 42,
+    branch: 'canductor/issue-1',
+    repo: 'acme/repo',
+    approved: false,
+    feedback: 'Please add error handling.',
+  },
+};
+
+const VERIFY_REQUESTED = {
+  data: { branch: 'canductor/issue-1', repo: 'acme/repo' },
+};
+
+describe('reviewRelay function', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let handler: (ctx: { event: unknown; step: ReturnType<typeof createMockStep> }) => Promise<any>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import('../src/functions/review-relay.js');
+    handler = mod.reviewRelay as typeof handler;
+    mockDispatchWorkflow.mockResolvedValue(undefined);
+    mockCommentOnIssue.mockResolvedValue(undefined);
+    mockGetPRReviewComments.mockResolvedValue('Fetched review comments.');
+  });
+
+  it('returns approved immediately when review is an approval', async () => {
+    const mockStep = createMockStep();
+    const result = await handler({
+      event: { data: { ...BASE_EVENT.data, approved: true } },
+      step: mockStep,
+    });
+
+    expect(result).toEqual({ status: 'approved', prNumber: 42, branch: 'canductor/issue-1' });
+    expect(mockDispatchWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('dispatches fix agent with feedback from event and returns fixed', async () => {
+    const mockStep = createMockStep();
+    mockStep.waitForEvent.mockResolvedValue(VERIFY_REQUESTED);
+
+    const result = await handler({ event: BASE_EVENT, step: mockStep });
+
+    expect(result).toEqual({ status: 'fixed', prNumber: 42, branch: 'canductor/issue-1', round: 1 });
+    expect(mockDispatchWorkflow).toHaveBeenCalledWith('acme/repo', 'agent.yml', {
+      issue_number: '42',
+      branch: 'canductor/issue-1',
+      prompt: expect.stringContaining('Please add error handling.'),
+    });
+    expect(mockGetPRReviewComments).not.toHaveBeenCalled();
+  });
+
+  it('fetches review comments from GitHub API when no feedback in event', async () => {
+    const mockStep = createMockStep();
+    mockStep.waitForEvent.mockResolvedValue(VERIFY_REQUESTED);
+
+    await handler({
+      event: { data: { ...BASE_EVENT.data, feedback: undefined } },
+      step: mockStep,
+    });
+
+    expect(mockGetPRReviewComments).toHaveBeenCalledWith('acme/repo', 42);
+    expect(mockDispatchWorkflow).toHaveBeenCalledWith('acme/repo', 'agent.yml', {
+      issue_number: '42',
+      branch: 'canductor/issue-1',
+      prompt: expect.stringContaining('Fetched review comments.'),
+    });
+  });
+
+  it('includes round number in fix prompt', async () => {
+    const mockStep = createMockStep();
+    mockStep.waitForEvent.mockResolvedValue(VERIFY_REQUESTED);
+
+    await handler({
+      event: { data: { ...BASE_EVENT.data, reviewRound: 1 } },
+      step: mockStep,
+    });
+
+    const prompt = mockDispatchWorkflow.mock.calls[0][2].prompt as string;
+    expect(prompt).toContain('round 2/3');
+  });
+
+  it('escalates to human after max rounds', async () => {
+    const mockStep = createMockStep();
+
+    const result = await handler({
+      event: { data: { ...BASE_EVENT.data, reviewRound: 3 } },
+      step: mockStep,
+    });
+
+    expect(result).toEqual({ status: 'escalated', prNumber: 42, branch: 'canductor/issue-1', rounds: 3 });
+    expect(mockCommentOnIssue).toHaveBeenCalledWith(
+      'acme/repo',
+      42,
+      expect.stringContaining('Human review required')
+    );
+    expect(mockDispatchWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('comments timeout and returns timeout status when agent does not push', async () => {
+    const mockStep = createMockStep();
+    mockStep.waitForEvent.mockResolvedValue(null);
+
+    const result = await handler({ event: BASE_EVENT, step: mockStep });
+
+    expect(result).toEqual({ status: 'timeout', prNumber: 42, branch: 'canductor/issue-1' });
+    expect(mockCommentOnIssue).toHaveBeenCalledWith(
+      'acme/repo',
+      42,
+      expect.stringContaining('timed out')
+    );
+  });
+
+  it('sends canductor/verify.requested after successful fix', async () => {
+    const { inngest: mockInngest } = await import('../src/inngest.js');
+    const mockStep = createMockStep();
+    mockStep.waitForEvent.mockResolvedValue(VERIFY_REQUESTED);
+
+    await handler({ event: BASE_EVENT, step: mockStep });
+
+    expect(mockInngest.send).toHaveBeenCalledWith({
+      name: 'canductor/verify.requested',
+      data: { branch: 'canductor/issue-1', repo: 'acme/repo', prNumber: 42 },
+    });
+  });
+
+  it('waits for verify.requested event on the correct branch', async () => {
+    const mockStep = createMockStep();
+    mockStep.waitForEvent.mockResolvedValue(VERIFY_REQUESTED);
+
+    await handler({ event: BASE_EVENT, step: mockStep });
+
+    expect(mockStep.waitForEvent).toHaveBeenCalledWith('wait-for-fix', {
+      event: 'canductor/verify.requested',
+      match: 'data.branch',
+      timeout: '60m',
+    });
+  });
+
+  it('defaults reviewRound to 0 when not provided', async () => {
+    const mockStep = createMockStep();
+    mockStep.waitForEvent.mockResolvedValue(VERIFY_REQUESTED);
+
+    const result = await handler({
+      event: { data: { prNumber: 42, branch: 'canductor/issue-1', repo: 'acme/repo', approved: false, feedback: 'fix this' } },
+      step: mockStep,
+    });
+
+    expect(result).toEqual({ status: 'fixed', prNumber: 42, branch: 'canductor/issue-1', round: 1 });
+  });
+});

--- a/packages/pipeline/src/functions/review-relay.ts
+++ b/packages/pipeline/src/functions/review-relay.ts
@@ -1,0 +1,81 @@
+import { inngest } from '../inngest.js';
+
+const MAX_ROUNDS = 3;
+
+export const reviewRelay = inngest.createFunction(
+  { id: 'canductor/review-relay', retries: 1 },
+  { event: 'canductor/pr.reviewed' },
+  async ({ event, step }) => {
+    const { prNumber, branch, repo, approved, feedback, reviewRound = 0 } = event.data;
+
+    // Nothing to fix if the review was an approval
+    if (approved) {
+      return { status: 'approved', prNumber, branch };
+    }
+
+    // Escalate to human after max rounds
+    if (reviewRound >= MAX_ROUNDS) {
+      await step.run('escalate-to-human', async () => {
+        const gh = await import('../github.js');
+        await gh.commentOnIssue(
+          repo,
+          prNumber,
+          `Review relay exhausted after ${MAX_ROUNDS} rounds on branch \`${branch}\`. Human review required.`
+        );
+      });
+      return { status: 'escalated', prNumber, branch, rounds: reviewRound };
+    }
+
+    // Get review comments — prefer inline feedback from event, fall back to GitHub API
+    const reviewComments = await step.run('get-review-comments', async () => {
+      if (feedback) return feedback;
+      const gh = await import('../github.js');
+      return await gh.getPRReviewComments(repo, prNumber);
+    });
+
+    // Dispatch fix agent with review context
+    const round = reviewRound + 1;
+    const fixPrompt =
+      `Fix review feedback on PR #${prNumber} (round ${round}/${MAX_ROUNDS}):\n\n` +
+      `${reviewComments}\n\n` +
+      `Address all review comments and push to branch \`${branch}\`.`;
+
+    await step.run('dispatch-fix', async () => {
+      const gh = await import('../github.js');
+      await gh.dispatchWorkflow(repo, 'agent.yml', {
+        issue_number: String(prNumber),
+        branch,
+        prompt: fixPrompt,
+      });
+    });
+
+    // Wait for agent to push changes (CI sends canductor/verify.requested)
+    const agentDone = await step.waitForEvent('wait-for-fix', {
+      event: 'canductor/verify.requested',
+      match: 'data.branch',
+      timeout: '60m',
+    });
+
+    if (!agentDone) {
+      await step.run('comment-timeout', async () => {
+        const gh = await import('../github.js');
+        await gh.commentOnIssue(
+          repo,
+          prNumber,
+          `Review fix agent timed out after 60 minutes on branch \`${branch}\`.`
+        );
+      });
+      return { status: 'timeout', prNumber, branch };
+    }
+
+    // Trigger re-verification so verify-and-fix picks up the new push
+    await step.run('trigger-reverify', async () => {
+      await inngest.send({
+        name: 'canductor/verify.requested',
+        data: { branch, repo, prNumber },
+      });
+    });
+
+    return { status: 'fixed', prNumber, branch, round };
+  }
+);

--- a/packages/pipeline/src/github.ts
+++ b/packages/pipeline/src/github.ts
@@ -106,6 +106,18 @@ export async function dispatchWorkflow(
   });
 }
 
+/** Get all review comments from a pull request as a formatted string. */
+export async function getPRReviewComments(repo: string, prNumber: number): Promise<string> {
+  const octokit = getOctokit();
+  const { owner, repo: repoName } = parseRepo(repo);
+  const { data } = await octokit.pulls.listReviews({ owner, repo: repoName, pull_number: prNumber });
+  const comments = data
+    .filter((r) => r.body && r.state !== 'APPROVED')
+    .map((r) => `[${r.user?.login ?? 'reviewer'}]: ${r.body}`)
+    .join('\n\n');
+  return comments || 'No specific comments provided.';
+}
+
 /** Close an issue and optionally add labels. */
 export async function closeIssue(
   repo: string,

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -3,4 +3,5 @@ export { implement } from './functions/implement.js';
 export { verifyAndFix } from './functions/verify-and-fix.js';
 export { autoMerge } from './functions/auto-merge.js';
 export { orchestrate } from './functions/orchestrate.js';
+export { reviewRelay } from './functions/review-relay.js';
 export type { CanductorEvents } from './types.js';

--- a/packages/pipeline/src/types.ts
+++ b/packages/pipeline/src/types.ts
@@ -12,6 +12,7 @@ export type CanductorEvents = {
       repo: string;
       approved: boolean;
       feedback?: string;
+      reviewRound?: number;
     };
   };
   'canductor/ci.completed': {


### PR DESCRIPTION
## Summary
- New `reviewRelay` Inngest function: listens for `canductor/pr.reviewed`, dispatches fix agent with review context, triggers re-verification
- Max 3 rounds before escalating to human
- `getPRReviewComments` helper in github.ts
- 9 tests covering approved/fix/escalate/timeout paths

Closes #4

Autonomously implemented by canductor pipeline. 