### PR TITLE
feat: add canductor diff command for quality comparison

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -21,6 +21,7 @@ import {
   generatePromptContext,
   injectContext,
   suggestRuleImprovements,
+  diffResults,
 } from '@canductor/core';
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
@@ -33,14 +34,15 @@ function printUsage(): void {
   console.log(`canductor — quality verification for agentic output
 
 Usage:
-  canductor verify [ref]     Run all layers, log result, print decision
-  canductor score [ref]      Run layers, print composite score only
-  canductor history          Show results history table
-  canductor context          Generate quality context for agent prompts
-  canductor inject <file>    Inject quality context into a file (e.g. CLAUDE.md)
-  canductor suggest          Suggest rule improvements based on history
-  canductor init             Create starter config
-  canductor help             Show this message
+  canductor verify [ref]        Run all layers, log result, print decision
+  canductor score [ref]         Run layers, print composite score only
+  canductor history             Show results history table
+  canductor diff <ref1> <ref2>  Compare quality scores between two refs
+  canductor context             Generate quality context for agent prompts
+  canductor inject <file>       Inject quality context into a file (e.g. CLAUDE.md)
+  canductor suggest             Suggest rule improvements based on history
+  canductor init                Create starter config
+  canductor help                Show this message
 `);
 }
 
@@ -149,6 +151,56 @@ function cmdHistory(): void {
   }
 }
 
+function cmdDiff(): void {
+  const ref1 = args[1];
+  const ref2 = args[2];
+  if (!ref1 || !ref2) {
+    console.error('Usage: canductor diff <ref1> <ref2>');
+    process.exit(1);
+  }
+
+  const diff = diffResults(repoRoot, ref1, ref2);
+  if (!diff) {
+    const results = readResults(repoRoot);
+    const found = results.map(r => r.ref);
+    if (!results.find(r => r.ref === ref1)) {
+      console.error(`Ref not found in results log: ${ref1}`);
+    }
+    if (!results.find(r => r.ref === ref2)) {
+      console.error(`Ref not found in results log: ${ref2}`);
+    }
+    if (found.length > 0) {
+      console.error(`Available refs: ${found.join(', ')}`);
+    }
+    process.exit(1);
+  }
+
+  const sign = (n: number) => (n > 0 ? `+${n}` : `${n}`);
+  const deltaStr = sign(diff.delta);
+
+  console.log(`\nDiff: ${diff.ref1} → ${diff.ref2}`);
+  console.log(`Composite score: ${diff.composite1} → ${diff.composite2} (${deltaStr})\n`);
+  console.log('Layer breakdown:');
+  console.log('  Layer'.padEnd(24) + 'Before'.padEnd(10) + 'After'.padEnd(10) + 'Change');
+  console.log('  ' + '-'.repeat(52));
+
+  for (const layer of diff.layers) {
+    const before = layer.score1 !== null ? String(layer.score1) : '—';
+    const after  = layer.score2 !== null ? String(layer.score2) : '—';
+    let changeLabel: string;
+    if (layer.change === 'improved')  changeLabel = `▲ +${layer.delta}`;
+    else if (layer.change === 'regressed') changeLabel = `▼ ${layer.delta}`;
+    else if (layer.change === 'unchanged') changeLabel = '= no change';
+    else if (layer.change === 'added')    changeLabel = '+ added';
+    else                                  changeLabel = '- removed';
+
+    console.log(
+      `  ${layer.name.padEnd(22)}${before.padEnd(10)}${after.padEnd(10)}${changeLabel}`
+    );
+  }
+  console.log('');
+}
+
 function cmdContext(): void {
   const context = generatePromptContext(repoRoot);
   console.log(context);
@@ -198,6 +250,9 @@ async function main(): Promise<void> {
       break;
     case 'history':
       cmdHistory();
+      break;
+    case 'diff':
+      cmdDiff();
       break;
     case 'context':
       cmdContext();

--- a/packages/core/__tests__/results.test.ts
+++ b/packages/core/__tests__/results.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { appendResult, readResults, analyzeResults, generatePromptContext } from '../src/results.js';
+import { appendResult, readResults, analyzeResults, generatePromptContext, diffResults } from '../src/results.js';
 import type { VerifyResult } from '../src/types.js';
 
 let tempDir: string;
@@ -75,6 +75,59 @@ describe('analyzeResults', () => {
     const allIssues = ctx.recurring_issues.join(' ');
     expect(allIssues).toContain('tests');
     expect(allIssues).toContain('ux');
+  });
+});
+
+describe('diffResults', () => {
+  it('returns null when either ref is not found', () => {
+    appendResult(tempDir, makeVerifyResult('#1', 85, true), 'merged', 'first');
+    expect(diffResults(tempDir, '#1', '#99')).toBeNull();
+    expect(diffResults(tempDir, '#99', '#1')).toBeNull();
+  });
+
+  it('computes composite delta and layer diffs', () => {
+    appendResult(tempDir, makeVerifyResult('#1', 70, false), 'rejected', 'first');
+    appendResult(tempDir, makeVerifyResult('#2', 90, true), 'merged', 'second');
+
+    const diff = diffResults(tempDir, '#1', '#2');
+    expect(diff).not.toBeNull();
+    expect(diff!.ref1).toBe('#1');
+    expect(diff!.ref2).toBe('#2');
+    expect(diff!.composite1).toBe(70);
+    expect(diff!.composite2).toBe(90);
+    expect(diff!.delta).toBe(20);
+  });
+
+  it('classifies layers as improved, regressed, or unchanged', () => {
+    // ref1: tests=0, ux=70 (pass=false gives tests=0, score=70 -> ux=70)
+    appendResult(tempDir, makeVerifyResult('#1', 70, false), 'rejected', 'low tests');
+    // ref2: tests=100, ux=90 (pass=true)
+    appendResult(tempDir, makeVerifyResult('#2', 90, true), 'merged', 'high tests');
+
+    const diff = diffResults(tempDir, '#1', '#2');
+    expect(diff).not.toBeNull();
+
+    const testsLayer = diff!.layers.find(l => l.name === 'tests');
+    expect(testsLayer).toBeDefined();
+    expect(testsLayer!.change).toBe('improved');
+    expect(testsLayer!.delta).toBe(100);
+
+    // ux went from 70 -> 90 (score param in makeVerifyResult)
+    const uxLayer = diff!.layers.find(l => l.name === 'ux');
+    expect(uxLayer).toBeDefined();
+    expect(uxLayer!.change).toBe('improved');
+  });
+
+  it('marks a layer as regressed when score drops', () => {
+    appendResult(tempDir, makeVerifyResult('#1', 90, true), 'merged', 'good');
+    appendResult(tempDir, makeVerifyResult('#2', 60, false), 'rejected', 'bad');
+
+    const diff = diffResults(tempDir, '#1', '#2');
+    expect(diff).not.toBeNull();
+    expect(diff!.delta).toBe(-30);
+
+    const testsLayer = diff!.layers.find(l => l.name === 'tests');
+    expect(testsLayer!.change).toBe('regressed');
   });
 });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,8 @@
 export { loadConfig, findConfigPath } from './config.js';
 export { verify, computeCompositeScore, evaluatePolicy } from './verify.js';
 export { runLayer, runDeterministicLayer, runScreenshotDiffLayer, runAgentReviewLayer } from './layers.js';
-export { readResults, appendResult, analyzeResults, generatePromptContext } from './results.js';
+export { readResults, appendResult, analyzeResults, generatePromptContext, diffResults } from './results.js';
+export type { LayerDiff, DiffResult } from './results.js';
 export { compareScreenshots, updateBaseline } from './screenshot.js';
 export type { ScreenshotDiffResult } from './screenshot.js';
 export { evaluateExpression, evaluateAllPolicies, buildPolicyContext } from './policy.js';

--- a/packages/core/src/results.ts
+++ b/packages/core/src/results.ts
@@ -138,6 +138,91 @@ export function analyzeResults(repoRoot: string): QualityContext {
   };
 }
 
+/** A single layer diff entry. */
+export interface LayerDiff {
+  name: string;
+  score1: number | null;
+  score2: number | null;
+  delta: number | null;
+  change: 'improved' | 'regressed' | 'unchanged' | 'added' | 'removed';
+}
+
+/** Result of comparing two refs from the results log. */
+export interface DiffResult {
+  ref1: string;
+  ref2: string;
+  composite1: number;
+  composite2: number;
+  delta: number;
+  layers: LayerDiff[];
+}
+
+/**
+ * Parse a layer_scores string ("tests:100,ux:80") into a map.
+ */
+function parseLayerScores(raw: string): Map<string, number> {
+  const map = new Map<string, number>();
+  if (!raw) return map;
+  for (const entry of raw.split(',')) {
+    const [name, val] = entry.split(':');
+    if (name && val !== undefined) map.set(name, parseFloat(val));
+  }
+  return map;
+}
+
+/**
+ * Compare two refs from the results log and show how quality changed.
+ * Returns null if either ref is not found.
+ */
+export function diffResults(repoRoot: string, ref1: string, ref2: string): DiffResult | null {
+  const results = readResults(repoRoot);
+
+  const row1 = results.find(r => r.ref === ref1);
+  const row2 = results.find(r => r.ref === ref2);
+
+  if (!row1 || !row2) return null;
+
+  const scores1 = parseLayerScores(row1.layer_scores);
+  const scores2 = parseLayerScores(row2.layer_scores);
+
+  const allLayers = new Set([...scores1.keys(), ...scores2.keys()]);
+  const layers: LayerDiff[] = [];
+
+  for (const name of allLayers) {
+    const s1 = scores1.has(name) ? scores1.get(name)! : null;
+    const s2 = scores2.has(name) ? scores2.get(name)! : null;
+
+    let change: LayerDiff['change'];
+    let delta: number | null = null;
+
+    if (s1 === null) {
+      change = 'added';
+    } else if (s2 === null) {
+      change = 'removed';
+    } else {
+      delta = s2 - s1;
+      if (delta > 0) change = 'improved';
+      else if (delta < 0) change = 'regressed';
+      else change = 'unchanged';
+    }
+
+    layers.push({ name, score1: s1, score2: s2, delta, change });
+  }
+
+  // Sort: regressed first, then improved, then unchanged, then added/removed
+  const order = { regressed: 0, improved: 1, unchanged: 2, added: 3, removed: 4 };
+  layers.sort((a, b) => order[a.change] - order[b.change]);
+
+  return {
+    ref1,
+    ref2,
+    composite1: row1.composite_score,
+    composite2: row2.composite_score,
+    delta: row2.composite_score - row1.composite_score,
+    layers,
+  };
+}
+
 /**
  * Generate a context block to inject into agent prompts.
  * This is what makes the agent "learn" from past results.


### PR DESCRIPTION
## The Proof: Canductor Built This Feature On Itself

This PR was autonomously implemented by the canductor pipeline — an AI agent picked up the story, read the codebase, implemented the feature, ran tests, and pushed.

### What it adds
- `canductor diff <ref1> <ref2>` — compares two entries in results.tsv
- Shows which layers improved, regressed, or stayed the same
- Human-readable terminal output with deltas
- 4 new tests

Closes #6