### PR TITLE
feat: add canductor baseline command

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,6 +15,8 @@
 
 import {
   loadConfig,
+  findConfigPath,
+  writeConfigBaseline,
   verify,
   appendResult,
   readResults,
@@ -24,6 +26,8 @@ import {
   diffResults,
   getStatus,
   getTrend,
+  computeAutoBaseline,
+  getBaseline,
 } from '@canductor/core';
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
@@ -42,6 +46,9 @@ Usage:
   canductor trend [--last N]    Show quality trend over last N results (default 10)
   canductor history             Show results history table
   canductor diff <ref1> <ref2>  Compare quality scores between two refs
+  canductor baseline             Show current quality baseline
+  canductor baseline --set N    Set baseline override to N
+  canductor baseline --auto     Set baseline from last 5 merged scores
   canductor context             Generate quality context for agent prompts
   canductor inject <file>       Inject quality context into a file (e.g. CLAUDE.md)
   canductor suggest             Suggest rule improvements based on history
@@ -270,6 +277,45 @@ function cmdStatus(): void {
   }
 }
 
+function cmdBaseline(): void {
+  const setIdx = args.indexOf('--set');
+  const autoMode = args.includes('--auto');
+
+  if (setIdx !== -1) {
+    const val = args[setIdx + 1];
+    if (!val || isNaN(parseInt(val, 10))) {
+      console.error('Usage: canductor baseline --set <number>');
+      process.exit(1);
+    }
+    const score = parseInt(val, 10);
+    if (score < 0 || score > 100) {
+      console.error('Baseline must be between 0 and 100');
+      process.exit(1);
+    }
+    writeConfigBaseline(repoRoot, score);
+    console.log(`Baseline set to ${score}/100`);
+    return;
+  }
+
+  if (autoMode) {
+    const score = computeAutoBaseline(repoRoot);
+    writeConfigBaseline(repoRoot, score);
+    console.log(`Baseline set to ${score}/100 (computed from last 5 merged scores)`);
+    return;
+  }
+
+  // Show current baseline
+  let config = null;
+  try {
+    config = loadConfig(repoRoot);
+  } catch {
+    // no config file — that's fine, we'll compute from results
+  }
+  const baseline = getBaseline(repoRoot, config);
+  const source = config?.baseline !== undefined ? 'config override' : 'computed from last 5 merged scores';
+  console.log(`Current baseline: ${baseline}/100 (${source})`);
+}
+
 function cmdContext(): void {
   const context = generatePromptContext(repoRoot);
   console.log(context);
@@ -328,6 +374,9 @@ async function main(): Promise<void> {
       break;
     case 'diff':
       cmdDiff();
+      break;
+    case 'baseline':
+      cmdBaseline();
       break;
     case 'context':
       cmdContext();

--- a/packages/core/__tests__/config.test.ts
+++ b/packages/core/__tests__/config.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadConfig, writeConfigBaseline } from '../src/config.js';
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'canductor-config-test-'));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function writeConfig(content: string): void {
+  const dir = join(tempDir, '.canductor');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'config.yaml'), content);
+}
+
+const minimalConfig = `version: 1
+layers:
+  tests:
+    name: tests
+    type: deterministic
+    run: "npm test"
+    weight: 1.0
+policy:
+  auto_merge: "all_pass"
+  human_review: "false"
+  block: "any_fail"
+`;
+
+describe('writeConfigBaseline', () => {
+  it('adds baseline to existing config', () => {
+    writeConfig(minimalConfig);
+    writeConfigBaseline(tempDir, 80);
+
+    const config = loadConfig(tempDir);
+    expect(config.baseline).toBe(80);
+  });
+
+  it('updates existing baseline value', () => {
+    writeConfig(minimalConfig + 'baseline: 50\n');
+    writeConfigBaseline(tempDir, 90);
+
+    const config = loadConfig(tempDir);
+    expect(config.baseline).toBe(90);
+  });
+
+  it('throws when no config file exists', () => {
+    expect(() => writeConfigBaseline(tempDir, 80)).toThrow('No canductor config found');
+  });
+});
+
+describe('loadConfig with baseline', () => {
+  it('loads config without baseline field', () => {
+    writeConfig(minimalConfig);
+    const config = loadConfig(tempDir);
+    expect(config.baseline).toBeUndefined();
+  });
+
+  it('loads config with baseline field', () => {
+    writeConfig(minimalConfig + 'baseline: 75\n');
+    const config = loadConfig(tempDir);
+    expect(config.baseline).toBe(75);
+  });
+});

--- a/packages/core/__tests__/results.test.ts
+++ b/packages/core/__tests__/results.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { appendResult, readResults, analyzeResults, generatePromptContext, diffResults, getStatus, getTrend } from '../src/results.js';
-import type { VerifyResult } from '../src/types.js';
+import { appendResult, readResults, analyzeResults, generatePromptContext, diffResults, getStatus, getTrend, computeAutoBaseline, getBaseline } from '../src/results.js';
+import type { VerifyResult, CanductorConfig } from '../src/types.js';
 
 let tempDir: string;
 
@@ -303,6 +303,64 @@ describe('getTrend', () => {
     expect(trend.entries[0].status).toBe('merged');
     expect(trend.entries[1].status).toBe('rejected');
     expect(trend.entries[2].status).toBe('pending');
+  });
+});
+
+describe('computeAutoBaseline', () => {
+  it('returns 0 when no results exist', () => {
+    expect(computeAutoBaseline(tempDir)).toBe(0);
+  });
+
+  it('computes average of last 5 merged scores', () => {
+    for (let i = 1; i <= 5; i++) {
+      appendResult(tempDir, makeVerifyResult(`#${i}`, 80 + i, true), 'merged', `pr ${i}`);
+    }
+    // (81+82+83+84+85) / 5 = 83
+    expect(computeAutoBaseline(tempDir)).toBe(83);
+  });
+
+  it('ignores rejected results', () => {
+    appendResult(tempDir, makeVerifyResult('#1', 90, true), 'merged', 'good');
+    appendResult(tempDir, makeVerifyResult('#2', 20, false), 'rejected', 'bad');
+    appendResult(tempDir, makeVerifyResult('#3', 80, true), 'merged', 'ok');
+    // Only merged: (90+80)/2 = 85
+    expect(computeAutoBaseline(tempDir)).toBe(85);
+  });
+
+  it('only uses last 5 merged scores', () => {
+    for (let i = 1; i <= 8; i++) {
+      appendResult(tempDir, makeVerifyResult(`#${i}`, 50 + i * 5, true), 'merged', `pr ${i}`);
+    }
+    // Last 5 merged: 70,75,80,85,90 -> avg = 80
+    expect(computeAutoBaseline(tempDir)).toBe(80);
+  });
+});
+
+describe('getBaseline', () => {
+  const makeConfig = (baseline?: number): CanductorConfig => ({
+    version: 1,
+    layers: {},
+    policy: { auto_merge: 'true', human_review: 'false', block: 'false' },
+    ...(baseline !== undefined ? { baseline } : {}),
+  });
+
+  it('uses config override when present', () => {
+    appendResult(tempDir, makeVerifyResult('#1', 90, true), 'merged', 'good');
+    expect(getBaseline(tempDir, makeConfig(50))).toBe(50);
+  });
+
+  it('falls back to computed baseline when no config override', () => {
+    appendResult(tempDir, makeVerifyResult('#1', 90, true), 'merged', 'good');
+    expect(getBaseline(tempDir, makeConfig())).toBe(90);
+  });
+
+  it('falls back to computed baseline when config is null', () => {
+    appendResult(tempDir, makeVerifyResult('#1', 85, true), 'merged', 'good');
+    expect(getBaseline(tempDir, null)).toBe(85);
+  });
+
+  it('returns 0 when no config and no results', () => {
+    expect(getBaseline(tempDir, null)).toBe(0);
   });
 });
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -2,9 +2,9 @@
  * Config loader — reads .canductor/config.yaml from the repo.
  */
 
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { parse as parseYaml } from 'yaml';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { z } from 'zod';
 import type { CanductorConfig } from './types.js';
 
@@ -31,6 +31,7 @@ const ConfigSchema = z.object({
   version: z.literal(1),
   layers: z.record(LayerSchema),
   policy: PolicySchema,
+  baseline: z.number().min(0).max(100).optional(),
 });
 
 const CONFIG_PATHS = [
@@ -59,4 +60,22 @@ export function loadConfig(repoRoot: string): CanductorConfig {
   const raw = readFileSync(configPath, 'utf-8');
   const parsed = parseYaml(raw);
   return ConfigSchema.parse(parsed);
+}
+
+/**
+ * Write a baseline value to the config YAML file.
+ * Preserves existing config and adds/updates the baseline field.
+ */
+export function writeConfigBaseline(repoRoot: string, baseline: number): void {
+  const configPath = findConfigPath(repoRoot);
+  if (!configPath) {
+    throw new Error(
+      `No canductor config found. Run: canductor init`
+    );
+  }
+
+  const raw = readFileSync(configPath, 'utf-8');
+  const parsed = parseYaml(raw);
+  parsed.baseline = baseline;
+  writeFileSync(configPath, stringifyYaml(parsed));
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
-export { loadConfig, findConfigPath } from './config.js';
+export { loadConfig, findConfigPath, writeConfigBaseline } from './config.js';
 export { verify, computeCompositeScore, evaluatePolicy } from './verify.js';
 export { runLayer, runDeterministicLayer, runScreenshotDiffLayer, runAgentReviewLayer } from './layers.js';
-export { readResults, appendResult, analyzeResults, generatePromptContext, diffResults, getStatus, getTrend } from './results.js';
+export { readResults, appendResult, analyzeResults, generatePromptContext, diffResults, getStatus, getTrend, computeAutoBaseline, getBaseline } from './results.js';
 export type { LayerDiff, DiffResult, PipelineStatus, TrendEntry, TrendResult } from './results.js';
 export { compareScreenshots, updateBaseline } from './screenshot.js';
 export type { ScreenshotDiffResult } from './screenshot.js';

--- a/packages/core/src/results.ts
+++ b/packages/core/src/results.ts
@@ -7,7 +7,7 @@
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import type { ResultRow, VerifyResult, QualityContext } from './types.js';
+import type { ResultRow, VerifyResult, QualityContext, CanductorConfig } from './types.js';
 
 const RESULTS_PATH = '.canductor/results.tsv';
 const HEADER = 'ref\ttimestamp\tcomposite_score\tdecision\tlayer_scores\tstatus\tdescription';
@@ -367,6 +367,32 @@ export function getTrend(repoRoot: string, last: number = 10): TrendResult {
     direction,
     delta,
   };
+}
+
+/**
+ * Compute the auto-baseline from the last 5 merged scores.
+ * Returns 0 if there are no merged results.
+ */
+export function computeAutoBaseline(repoRoot: string): number {
+  const results = readResults(repoRoot);
+  const mergedScores = results
+    .filter(r => r.status === 'merged')
+    .map(r => r.composite_score)
+    .slice(-5);
+  return mergedScores.length > 0
+    ? Math.round(mergedScores.reduce((a, b) => a + b, 0) / mergedScores.length)
+    : 0;
+}
+
+/**
+ * Get the effective baseline score.
+ * If a config override exists, use that. Otherwise compute from results history.
+ */
+export function getBaseline(repoRoot: string, config: CanductorConfig | null): number {
+  if (config?.baseline !== undefined) {
+    return config.baseline;
+  }
+  return computeAutoBaseline(repoRoot);
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -40,6 +40,8 @@ export interface CanductorConfig {
   version: 1;
   layers: Record<string, LayerConfig>;
   policy: PolicyConfig;
+  /** Optional baseline override. When set, takes precedence over computed baseline. */
+  baseline?: number;
 }
 
 /** Result of running a single verification layer. */


### PR DESCRIPTION
## Summary
- Adds `canductor baseline` CLI command with three modes: show current baseline, `--set N` to override, `--auto` to compute from last 5 merged scores
- Adds `computeAutoBaseline`, `getBaseline`, and `writeConfigBaseline` core functions
- Adds optional `baseline` field to `CanductorConfig` type and config schema

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes — 126 tests (including 13 new baseline/config tests)
- [ ] Manual: `canductor baseline` shows current baseline
- [ ] Manual: `canductor baseline --set 80` writes to config.yaml
- [ ] Manual: `canductor baseline --auto` computes and sets from history

Closes #16

https://claude.ai/code/session_01Gn3WkLpK36oXk9MmDM1NZi