### PR TITLE
feat: agent-review layer works without API key via self-review mode

### DIFF
--- a/.canductor/results.tsv
+++ b/.canductor/results.tsv
@@ -1,2 +1,3 @@
 ref	timestamp	composite_score	decision	layer_scores	status	description
 pipeline-migration	2026-03-23T18:17:24.970Z	77	auto_merge	typecheck:100,tests:100,code_quality:0	pending	Verified pipeline-migration
+18	2026-03-23T18:22:01.743Z	98	auto_merge	typecheck:100,tests:100,code_quality:91	pending	Verified 18

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -28,7 +28,10 @@ import {
   getTrend,
   computeAutoBaseline,
   getBaseline,
+  getAgentReviewPrompt,
+  parseReviewJson,
 } from '@canductor/core';
+import type { AgentReviewResult } from '@canductor/core';
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
@@ -40,20 +43,22 @@ function printUsage(): void {
   console.log(`canductor — quality verification for agentic output
 
 Usage:
-  canductor verify [ref]        Run all layers, log result, print decision
-  canductor score [ref]         Run layers, print composite score only
-  canductor status              Show pipeline health overview
-  canductor trend [--last N]    Show quality trend over last N results (default 10)
-  canductor history             Show results history table
-  canductor diff <ref1> <ref2>  Compare quality scores between two refs
-  canductor baseline             Show current quality baseline
-  canductor baseline --set N    Set baseline override to N
-  canductor baseline --auto     Set baseline from last 5 merged scores
-  canductor context             Generate quality context for agent prompts
-  canductor inject <file>       Inject quality context into a file (e.g. CLAUDE.md)
-  canductor suggest             Suggest rule improvements based on history
-  canductor init                Create starter config
-  canductor help                Show this message
+  canductor verify [ref]                     Run all layers, log result, print decision
+  canductor verify [ref] --self-review       Output review prompt for agent-review layers (no API key needed)
+  canductor verify [ref] --review-json <j>   Use pre-evaluated review JSON for agent-review layers
+  canductor score [ref]                      Run layers, print composite score only
+  canductor status                           Show pipeline health overview
+  canductor trend [--last N]                 Show quality trend over last N results (default 10)
+  canductor history                          Show results history table
+  canductor diff <ref1> <ref2>               Compare quality scores between two refs
+  canductor baseline                         Show current quality baseline
+  canductor baseline --set N                 Set baseline override to N
+  canductor baseline --auto                  Set baseline from last 5 merged scores
+  canductor context                          Generate quality context for agent prompts
+  canductor inject <file>                    Inject quality context into a file (e.g. CLAUDE.md)
+  canductor suggest                          Suggest rule improvements based on history
+  canductor init                             Create starter config
+  canductor help                             Show this message
 `);
 }
 
@@ -113,10 +118,55 @@ policy:
 }
 
 async function cmdVerify(): Promise<void> {
-  const ref = args[1] ?? 'HEAD';
+  const ref = args[1] && !args[1].startsWith('--') ? args[1] : 'HEAD';
   const jsonMode = args.includes('--json');
+  const selfReviewMode = args.includes('--self-review');
+  const reviewJsonIdx = args.indexOf('--review-json');
   const config = loadConfig(repoRoot);
-  const result = await verify(ref, config);
+
+  // Self-review mode: output the review prompt for agent-review layers and exit
+  if (selfReviewMode) {
+    let foundPrompt = false;
+    for (const [name, layerConfig] of Object.entries(config.layers)) {
+      if (layerConfig.type !== 'agent-review') continue;
+      const prompt = getAgentReviewPrompt({ ...layerConfig, name });
+      if (!prompt) {
+        console.error(`Could not build review prompt for layer "${name}"`);
+        continue;
+      }
+      foundPrompt = true;
+      console.log(`=== CANDUCTOR SELF-REVIEW: ${name} ===`);
+      console.log('Evaluate the following code against this rubric and respond with JSON:');
+      console.log('{"pass": boolean, "score": 0-100, "issues": [...], "summary": "..."}');
+      console.log('');
+      console.log(prompt.userPrompt);
+      console.log(`=== END SELF-REVIEW: ${name} ===`);
+    }
+    if (!foundPrompt) {
+      console.log('No agent-review layers found in config.');
+    }
+    return;
+  }
+
+  // Review-json mode: parse provided JSON for agent-review layers
+  let selfReviewResults: Record<string, AgentReviewResult> | undefined;
+  if (reviewJsonIdx !== -1) {
+    const rawJson = args[reviewJsonIdx + 1];
+    if (!rawJson) {
+      console.error('--review-json requires a JSON argument');
+      process.exit(1);
+    }
+    const parsed = parseReviewJson(rawJson);
+    // Apply the parsed result to all agent-review layers
+    selfReviewResults = {};
+    for (const [name, layerConfig] of Object.entries(config.layers)) {
+      if (layerConfig.type === 'agent-review') {
+        selfReviewResults[name] = parsed;
+      }
+    }
+  }
+
+  const result = await verify(ref, config, selfReviewResults);
 
   if (jsonMode) {
     console.log(JSON.stringify({

--- a/packages/core/__tests__/agent-review.test.ts
+++ b/packages/core/__tests__/agent-review.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Must import after setting up mocks
+const TEST_DIR = join(tmpdir(), `canductor-agent-review-test-${Date.now()}`);
+
+describe('buildReviewPrompt', () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('builds prompt from rubric and context files', async () => {
+    const { buildReviewPrompt } = await import('../src/agent-review.js');
+    const rubricPath = join(TEST_DIR, 'rubric.md');
+    const codePath = join(TEST_DIR, 'code.ts');
+    writeFileSync(rubricPath, '# Test Rubric\n- Check for errors');
+    writeFileSync(codePath, 'export function hello() { return "world"; }');
+
+    const prompt = buildReviewPrompt(rubricPath, [codePath]);
+
+    expect(prompt).not.toBeNull();
+    expect(prompt!.systemPrompt).toContain('code quality reviewer');
+    expect(prompt!.userPrompt).toContain('# Test Rubric');
+    expect(prompt!.userPrompt).toContain('hello');
+    expect(prompt!.rubricContent).toBe('# Test Rubric\n- Check for errors');
+    expect(prompt!.contextFileCount).toBe(1);
+  });
+
+  it('returns null when rubric file does not exist', async () => {
+    const { buildReviewPrompt } = await import('../src/agent-review.js');
+
+    const prompt = buildReviewPrompt('/nonexistent/rubric.md', []);
+
+    expect(prompt).toBeNull();
+  });
+
+  it('collects files from directories', async () => {
+    const { buildReviewPrompt } = await import('../src/agent-review.js');
+    const rubricPath = join(TEST_DIR, 'rubric.md');
+    const srcDir = join(TEST_DIR, 'src');
+    mkdirSync(srcDir, { recursive: true });
+    writeFileSync(rubricPath, '# Rubric');
+    writeFileSync(join(srcDir, 'a.ts'), 'const a = 1;');
+    writeFileSync(join(srcDir, 'b.ts'), 'const b = 2;');
+
+    const prompt = buildReviewPrompt(rubricPath, [srcDir]);
+
+    expect(prompt).not.toBeNull();
+    expect(prompt!.contextFileCount).toBe(2);
+    expect(prompt!.userPrompt).toContain('const a = 1');
+    expect(prompt!.userPrompt).toContain('const b = 2');
+  });
+});
+
+describe('parseReviewJson', () => {
+  it('parses valid JSON', async () => {
+    const { parseReviewJson } = await import('../src/agent-review.js');
+
+    const result = parseReviewJson(JSON.stringify({
+      pass: true,
+      score: 85,
+      issues: [{ severity: 'low', description: 'Minor style issue' }],
+      summary: 'Good code',
+    }));
+
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(85);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].severity).toBe('low');
+    expect(result.summary).toBe('Good code');
+  });
+
+  it('parses JSON wrapped in markdown code blocks', async () => {
+    const { parseReviewJson } = await import('../src/agent-review.js');
+
+    const result = parseReviewJson('```json\n{"pass": false, "score": 40, "issues": [], "summary": "Needs work"}\n```');
+
+    expect(result.pass).toBe(false);
+    expect(result.score).toBe(40);
+    expect(result.summary).toBe('Needs work');
+  });
+
+  it('clamps score to 0-100 range', async () => {
+    const { parseReviewJson } = await import('../src/agent-review.js');
+
+    const over = parseReviewJson('{"pass": true, "score": 150, "issues": [], "summary": "ok"}');
+    expect(over.score).toBe(100);
+
+    const under = parseReviewJson('{"pass": true, "score": -10, "issues": [], "summary": "ok"}');
+    expect(under.score).toBe(0);
+  });
+
+  it('infers pass from score when pass is not boolean', async () => {
+    const { parseReviewJson } = await import('../src/agent-review.js');
+
+    const result = parseReviewJson('{"pass": "yes", "score": 90, "issues": [], "summary": "ok"}');
+    expect(result.pass).toBe(true); // score >= 80
+
+    const failResult = parseReviewJson('{"pass": "yes", "score": 50, "issues": [], "summary": "ok"}');
+    expect(failResult.pass).toBe(false); // score < 80
+  });
+
+  it('throws on invalid JSON', async () => {
+    const { parseReviewJson } = await import('../src/agent-review.js');
+
+    expect(() => parseReviewJson('not json')).toThrow();
+  });
+});
+
+describe('runAgentReview', () => {
+  const originalEnv = process.env.ANTHROPIC_API_KEY;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.ANTHROPIC_API_KEY = originalEnv;
+    } else {
+      delete process.env.ANTHROPIC_API_KEY;
+    }
+  });
+
+  it('returns skipped result when no API key', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    const { runAgentReview } = await import('../src/agent-review.js');
+
+    const result = await runAgentReview('/some/rubric.md', [], 'claude-sonnet-4-6');
+
+    expect(result.score).toBe(0);
+    expect(result.summary).toContain('Skipped');
+    expect(result.summary).toContain('ANTHROPIC_API_KEY');
+  });
+});

--- a/packages/core/__tests__/self-review.test.ts
+++ b/packages/core/__tests__/self-review.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runAgentReviewLayer, getAgentReviewPrompt } from '../src/layers.js';
+import { computeCompositeScore } from '../src/verify.js';
+import type { LayerConfig, CanductorConfig, AgentReviewResult, LayerResult } from '../src/types.js';
+
+const TEST_DIR = join(tmpdir(), `canductor-self-review-test-${Date.now()}`);
+
+describe('runAgentReviewLayer with selfReviewResult', () => {
+  it('uses provided result instead of calling API', async () => {
+    const layer: LayerConfig = {
+      name: 'code_quality',
+      type: 'agent-review',
+      rubric: '/some/rubric.md',
+      context: [],
+      weight: 0.6,
+    };
+
+    const selfReviewResult: AgentReviewResult = {
+      pass: true,
+      score: 88,
+      issues: [{ severity: 'low', description: 'Minor naming issue' }],
+      summary: 'Good quality code',
+    };
+
+    const result = await runAgentReviewLayer(layer, selfReviewResult);
+
+    expect(result.name).toBe('code_quality');
+    expect(result.type).toBe('agent-review');
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(88);
+    expect(result.errors).toContain('[low] Minor naming issue');
+  });
+
+  it('uses provided failing result correctly', async () => {
+    const layer: LayerConfig = {
+      name: 'code_quality',
+      type: 'agent-review',
+      rubric: '/some/rubric.md',
+      context: [],
+      weight: 0.6,
+    };
+
+    const selfReviewResult: AgentReviewResult = {
+      pass: false,
+      score: 45,
+      issues: [
+        { severity: 'critical', description: 'Uses any type' },
+        { severity: 'high', description: 'Missing error handling' },
+      ],
+      summary: 'Needs improvement',
+    };
+
+    const result = await runAgentReviewLayer(layer, selfReviewResult);
+
+    expect(result.pass).toBe(false);
+    expect(result.score).toBe(45);
+    expect(result.errors).toContain('[critical] Uses any type');
+    expect(result.errors).toContain('[high] Missing error handling');
+  });
+
+  it('uses summary as errors when no issues', async () => {
+    const layer: LayerConfig = {
+      name: 'code_quality',
+      type: 'agent-review',
+      rubric: '/some/rubric.md',
+      context: [],
+      weight: 0.6,
+    };
+
+    const selfReviewResult: AgentReviewResult = {
+      pass: true,
+      score: 95,
+      issues: [],
+      summary: 'Excellent code',
+    };
+
+    const result = await runAgentReviewLayer(layer, selfReviewResult);
+
+    expect(result.errors).toBe('Excellent code');
+  });
+});
+
+describe('getAgentReviewPrompt', () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('returns prompt for layer with rubric', () => {
+    const rubricPath = join(TEST_DIR, 'rubric.md');
+    writeFileSync(rubricPath, '# Quality Check');
+
+    const layer: LayerConfig = {
+      name: 'code_quality',
+      type: 'agent-review',
+      rubric: rubricPath,
+      context: [],
+      weight: 0.6,
+    };
+
+    const prompt = getAgentReviewPrompt(layer);
+
+    expect(prompt).not.toBeNull();
+    expect(prompt!.rubricContent).toBe('# Quality Check');
+  });
+
+  it('returns null for layer without rubric', () => {
+    const layer: LayerConfig = {
+      name: 'code_quality',
+      type: 'agent-review',
+      weight: 0.6,
+    };
+
+    const prompt = getAgentReviewPrompt(layer);
+
+    expect(prompt).toBeNull();
+  });
+});
+
+describe('composite score with self-review results', () => {
+  it('includes agent-review score from self-review in composite', () => {
+    const config: CanductorConfig = {
+      version: 1,
+      layers: {
+        tests: { name: 'tests', type: 'deterministic', run: 'echo ok', weight: 1.0 },
+        code_quality: { name: 'code_quality', type: 'agent-review', rubric: 'r.md', weight: 0.6 },
+      },
+      policy: {
+        auto_merge: 'all_pass',
+        human_review: 'any_agent_review_fail',
+        block: 'any_deterministic_fail',
+      },
+    };
+
+    const results: LayerResult[] = [
+      { name: 'tests', type: 'deterministic', pass: true, score: 100, errors: '', duration_ms: 50 },
+      { name: 'code_quality', type: 'agent-review', pass: true, score: 85, errors: '', duration_ms: 10 },
+    ];
+
+    // (100*1.0 + 85*0.6) / (1.0 + 0.6) = (100 + 51) / 1.6 = 94.375 → 94
+    const score = computeCompositeScore(results, config);
+    expect(score).toBe(94);
+  });
+});

--- a/packages/core/src/agent-review.ts
+++ b/packages/core/src/agent-review.ts
@@ -1,12 +1,17 @@
 /**
  * Agent review — sends code + rubric to the Anthropic Claude API
  * and parses a structured quality verdict.
+ *
+ * Supports two modes:
+ * 1. API mode: When ANTHROPIC_API_KEY is set, calls Claude API directly
+ * 2. Self-review mode: When no API key, builds the review prompt for
+ *    the parent Claude Code session to evaluate inline
  */
 
 import Anthropic from '@anthropic-ai/sdk';
 import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
 import { join, extname } from 'node:path';
-import type { AgentReviewResult } from './types.js';
+import type { AgentReviewResult, SelfReviewPrompt } from './types.js';
 
 const SYSTEM_PROMPT = `You are a code quality reviewer. Evaluate the provided code against the rubric criteria.
 Respond with ONLY a JSON object matching this schema:
@@ -88,6 +93,72 @@ function readFilesWithLimit(
 }
 
 /**
+ * Build the review prompt from a rubric file and context paths.
+ * Reused by both API mode and self-review mode.
+ *
+ * Returns null if the rubric file cannot be read.
+ */
+export function buildReviewPrompt(
+  rubric: string,
+  context: string[]
+): SelfReviewPrompt | null {
+  let rubricContent: string;
+  try {
+    rubricContent = readFileSync(rubric, 'utf-8');
+  } catch {
+    return null;
+  }
+
+  const allPaths: string[] = [];
+  for (const ctx of context) {
+    if (!existsSync(ctx)) continue;
+    const stat = statSync(ctx);
+    if (stat.isDirectory()) {
+      collectFiles(ctx, allPaths);
+    } else {
+      allPaths.push(ctx);
+    }
+  }
+
+  const contextFiles = readFilesWithLimit(allPaths);
+  const contextBlock = contextFiles
+    .map(f => `### ${f.path}\n\`\`\`\n${f.content}\n\`\`\``)
+    .join('\n\n');
+
+  const userPrompt = `## Rubric\n\n${rubricContent}\n\n## Code to Review\n\n${contextBlock}`;
+
+  return {
+    systemPrompt: SYSTEM_PROMPT,
+    userPrompt,
+    rubricContent,
+    contextFileCount: contextFiles.length,
+  };
+}
+
+/**
+ * Parse a JSON string (possibly wrapped in markdown code blocks) into
+ * an AgentReviewResult. Returns a validated/normalized result.
+ *
+ * Throws if the JSON is unparseable.
+ */
+export function parseReviewJson(raw: string): AgentReviewResult {
+  let jsonStr = raw.trim();
+  const codeBlockMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (codeBlockMatch) {
+    jsonStr = codeBlockMatch[1].trim();
+  }
+
+  const parsed = JSON.parse(jsonStr) as AgentReviewResult;
+
+  return {
+    pass: typeof parsed.pass === 'boolean' ? parsed.pass : parsed.score >= 80,
+    score: Math.max(0, Math.min(100, typeof parsed.score === 'number' ? parsed.score : 0)),
+    issues: Array.isArray(parsed.issues) ? parsed.issues : [],
+    summary: typeof parsed.summary === 'string' ? parsed.summary : 'Agent review complete',
+  };
+}
+
+/**
  * Run an agent review by calling the Anthropic Claude API.
  *
  * @param rubric  - Path to the rubric markdown file
@@ -109,11 +180,8 @@ export async function runAgentReview(
     };
   }
 
-  // Read the rubric
-  let rubricContent: string;
-  try {
-    rubricContent = readFileSync(rubric, 'utf-8');
-  } catch {
+  const prompt = buildReviewPrompt(rubric, context);
+  if (!prompt) {
     return {
       pass: true,
       score: 0,
@@ -122,35 +190,14 @@ export async function runAgentReview(
     };
   }
 
-  // Collect and read context files
-  const allPaths: string[] = [];
-  for (const ctx of context) {
-    if (!existsSync(ctx)) continue;
-    const stat = statSync(ctx);
-    if (stat.isDirectory()) {
-      collectFiles(ctx, allPaths);
-    } else {
-      allPaths.push(ctx);
-    }
-  }
-
-  const contextFiles = readFilesWithLimit(allPaths);
-
-  // Build the user prompt
-  const contextBlock = contextFiles
-    .map(f => `### ${f.path}\n\`\`\`\n${f.content}\n\`\`\``)
-    .join('\n\n');
-
-  const userPrompt = `## Rubric\n\n${rubricContent}\n\n## Code to Review\n\n${contextBlock}`;
-
   // Call the Anthropic API
   try {
     const client = new Anthropic();
     const message = await client.messages.create({
       model,
       max_tokens: 1024,
-      system: SYSTEM_PROMPT,
-      messages: [{ role: 'user', content: userPrompt }],
+      system: prompt.systemPrompt,
+      messages: [{ role: 'user', content: prompt.userPrompt }],
     });
 
     // Extract text from response
@@ -164,22 +211,7 @@ export async function runAgentReview(
       };
     }
 
-    // Parse JSON from response (handle markdown code blocks)
-    let jsonStr = textBlock.text.trim();
-    const codeBlockMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)```/);
-    if (codeBlockMatch) {
-      jsonStr = codeBlockMatch[1].trim();
-    }
-
-    const parsed = JSON.parse(jsonStr) as AgentReviewResult;
-
-    // Validate and normalize the result
-    return {
-      pass: typeof parsed.pass === 'boolean' ? parsed.pass : parsed.score >= 80,
-      score: Math.max(0, Math.min(100, typeof parsed.score === 'number' ? parsed.score : 0)),
-      issues: Array.isArray(parsed.issues) ? parsed.issues : [],
-      summary: typeof parsed.summary === 'string' ? parsed.summary : 'Agent review complete',
-    };
+    return parseReviewJson(textBlock.text);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     return {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,13 +1,13 @@
 export { loadConfig, findConfigPath, writeConfigBaseline } from './config.js';
 export { verify, computeCompositeScore, evaluatePolicy } from './verify.js';
-export { runLayer, runDeterministicLayer, runScreenshotDiffLayer, runAgentReviewLayer } from './layers.js';
+export { runLayer, runDeterministicLayer, runScreenshotDiffLayer, runAgentReviewLayer, getAgentReviewPrompt } from './layers.js';
 export { readResults, appendResult, analyzeResults, generatePromptContext, diffResults, getStatus, getTrend, computeAutoBaseline, getBaseline } from './results.js';
 export type { LayerDiff, DiffResult, PipelineStatus, TrendEntry, TrendResult } from './results.js';
 export { compareScreenshots, updateBaseline } from './screenshot.js';
 export type { ScreenshotDiffResult } from './screenshot.js';
 export { evaluateExpression, evaluateAllPolicies, buildPolicyContext } from './policy.js';
 export type { PolicyContext } from './policy.js';
-export { runAgentReview } from './agent-review.js';
+export { runAgentReview, buildReviewPrompt, parseReviewJson } from './agent-review.js';
 export { injectContext, suggestRuleImprovements } from './feedback.js';
 export type {
   CanductorConfig,
@@ -18,5 +18,6 @@ export type {
   ResultRow,
   QualityContext,
   AgentReviewResult,
+  SelfReviewPrompt,
   RuleImprovement,
 } from './types.js';

--- a/packages/core/src/layers.ts
+++ b/packages/core/src/layers.ts
@@ -4,8 +4,8 @@
 
 import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import type { LayerConfig, LayerResult } from './types.js';
-import { runAgentReview } from './agent-review.js';
+import type { LayerConfig, LayerResult, AgentReviewResult, SelfReviewPrompt } from './types.js';
+import { runAgentReview, buildReviewPrompt } from './agent-review.js';
 import { compareScreenshots } from './screenshot.js';
 
 /** Run a deterministic layer (shell command, pass/fail). */
@@ -117,8 +117,17 @@ export function runScreenshotDiffLayer(layer: LayerConfig): LayerResult {
   };
 }
 
-/** Run an agent-review layer (send context + rubric to LLM, parse verdict). */
-export async function runAgentReviewLayer(layer: LayerConfig): Promise<LayerResult> {
+/**
+ * Run an agent-review layer (send context + rubric to LLM, parse verdict).
+ *
+ * @param layer - Layer configuration
+ * @param selfReviewResult - Pre-evaluated result for self-review mode.
+ *   When provided, skips the API call and uses this result directly.
+ */
+export async function runAgentReviewLayer(
+  layer: LayerConfig,
+  selfReviewResult?: AgentReviewResult
+): Promise<LayerResult> {
   const start = Date.now();
 
   if (!layer.rubric) {
@@ -128,6 +137,18 @@ export async function runAgentReviewLayer(layer: LayerConfig): Promise<LayerResu
       pass: true,
       score: 100,
       errors: 'No rubric file specified — skipping agent review',
+      duration_ms: Date.now() - start,
+    };
+  }
+
+  // Use pre-evaluated result if provided (self-review mode)
+  if (selfReviewResult) {
+    return {
+      name: layer.name,
+      type: 'agent-review',
+      pass: selfReviewResult.pass,
+      score: selfReviewResult.score,
+      errors: selfReviewResult.issues.map(i => `[${i.severity}] ${i.description}`).join('\n') || selfReviewResult.summary,
       duration_ms: Date.now() - start,
     };
   }
@@ -147,15 +168,32 @@ export async function runAgentReviewLayer(layer: LayerConfig): Promise<LayerResu
   };
 }
 
-/** Dispatch to the correct layer executor based on type. */
-export async function runLayer(layer: LayerConfig): Promise<LayerResult> {
+/**
+ * Build the self-review prompt for an agent-review layer.
+ * Returns null if the layer has no rubric or the rubric can't be read.
+ */
+export function getAgentReviewPrompt(layer: LayerConfig): SelfReviewPrompt | null {
+  if (!layer.rubric) return null;
+  return buildReviewPrompt(layer.rubric, layer.context ?? []);
+}
+
+/**
+ * Dispatch to the correct layer executor based on type.
+ *
+ * @param layer - Layer configuration
+ * @param selfReviewResult - Optional pre-evaluated result for agent-review layers
+ */
+export async function runLayer(
+  layer: LayerConfig,
+  selfReviewResult?: AgentReviewResult
+): Promise<LayerResult> {
   switch (layer.type) {
     case 'deterministic':
       return runDeterministicLayer(layer);
     case 'screenshot-diff':
       return runScreenshotDiffLayer(layer);
     case 'agent-review':
-      return runAgentReviewLayer(layer);
+      return runAgentReviewLayer(layer, selfReviewResult);
     default:
       return {
         name: layer.name,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -89,6 +89,14 @@ export interface AgentReviewResult {
   summary: string;
 }
 
+/** Structured prompt for self-review mode (no API key). */
+export interface SelfReviewPrompt {
+  systemPrompt: string;
+  userPrompt: string;
+  rubricContent: string;
+  contextFileCount: number;
+}
+
 /** A suggested improvement to quality rules based on results history. */
 export interface RuleImprovement {
   type: 'add_rule' | 'add_rubric_check' | 'update_baseline';

--- a/packages/core/src/verify.ts
+++ b/packages/core/src/verify.ts
@@ -3,7 +3,7 @@
  * evaluates policy, returns a decision.
  */
 
-import type { CanductorConfig, LayerResult, VerifyResult } from './types.js';
+import type { CanductorConfig, LayerResult, VerifyResult, AgentReviewResult } from './types.js';
 import { runLayer } from './layers.js';
 import { buildPolicyContext, evaluateAllPolicies } from './policy.js';
 
@@ -62,12 +62,24 @@ function buildSummary(results: LayerResult[], decision: string): string {
   return `Decision: ${decision}\n${lines.join('\n')}`;
 }
 
-/** Run all verification layers and return a complete result. */
-export async function verify(ref: string, config: CanductorConfig): Promise<VerifyResult> {
+/**
+ * Run all verification layers and return a complete result.
+ *
+ * @param ref - Git ref (PR number, branch, or commit)
+ * @param config - Canductor configuration
+ * @param selfReviewResults - Optional map of layer name → pre-evaluated agent review result.
+ *   Used in self-review mode to inject results from the parent Claude session.
+ */
+export async function verify(
+  ref: string,
+  config: CanductorConfig,
+  selfReviewResults?: Record<string, AgentReviewResult>
+): Promise<VerifyResult> {
   const results: LayerResult[] = [];
 
   for (const [name, layerConfig] of Object.entries(config.layers)) {
-    const result = await runLayer({ ...layerConfig, name });
+    const reviewResult = selfReviewResults?.[name];
+    const result = await runLayer({ ...layerConfig, name }, reviewResult);
     results.push(result);
   }
 


### PR DESCRIPTION
Closes #18 — implemented autonomously.

Adds self-review mode for the agent-review layer so canductor verify produces a full 3-layer score when run inside Claude Code sessions without ANTHROPIC_API_KEY.

## Changes
- Extract `buildReviewPrompt` and `parseReviewJson` from agent-review.ts for reuse
- Add `getAgentReviewPrompt` to layers.ts for building review prompts
- `runAgentReviewLayer` and `verify` accept optional pre-evaluated AgentReviewResult
- CLI: `--self-review` flag outputs the review prompt for parent Claude to evaluate
- CLI: `--review-json` flag accepts pre-evaluated JSON result for agent-review layers
- 15 new tests covering both API and self-review modes

Canductor score: 98/100 (auto_merge)