### PR TITLE
Add verify integration tests for full verify → score → policy flow

### DIFF
--- a/.canductor/results.tsv
+++ b/.canductor/results.tsv
@@ -3,3 +3,4 @@ pipeline-migration	2026-03-23T18:17:24.970Z	77	auto_merge	typecheck:100,tests:10
 18	2026-03-23T18:22:01.743Z	98	auto_merge	typecheck:100,tests:100,code_quality:91	pending	Verified 18
 21	2026-03-23T19:07:55.995Z	98	auto_merge	typecheck:100,tests:100,code_quality:91	pending	Verified 21
 22	2026-03-23T19:10:40.024Z	98	auto_merge	typecheck:100,tests:100,code_quality:92	pending	Verified 22
+23	2026-03-23T19:12:22.712Z	98	auto_merge	typecheck:100,tests:100,code_quality:93	pending	Verified 23

--- a/packages/core/__tests__/verify.test.ts
+++ b/packages/core/__tests__/verify.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { computeCompositeScore, evaluatePolicy } from '../src/verify.js';
-import type { CanductorConfig, LayerResult } from '../src/types.js';
+import { computeCompositeScore, evaluatePolicy, verify } from '../src/verify.js';
+import type { CanductorConfig, LayerResult, AgentReviewResult } from '../src/types.js';
 
 const baseConfig: CanductorConfig = {
   version: 1,
@@ -63,5 +63,186 @@ describe('evaluatePolicy', () => {
       makeResult('ux', 'agent-review', false, 45),
     ];
     expect(evaluatePolicy(results, 70, baseConfig)).toBe('human_review');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verify() integration tests
+// ---------------------------------------------------------------------------
+describe('verify() integration', () => {
+  it('runs deterministic layers and produces auto_merge decision', async () => {
+    const config: CanductorConfig = {
+      version: 1,
+      layers: {
+        echo_pass: {
+          name: 'echo_pass',
+          type: 'deterministic',
+          run: 'echo ok',
+          weight: 1.0,
+        },
+      },
+      policy: {
+        auto_merge: 'all_pass',
+        human_review: 'any_agent_review_fail',
+        block: 'any_deterministic_fail',
+      },
+    };
+
+    const result = await verify('test-ref', config);
+
+    expect(result.ref).toBe('test-ref');
+    expect(result.composite_score).toBe(100);
+    expect(result.decision).toBe('auto_merge');
+    expect(result.layers).toHaveLength(1);
+    expect(result.layers[0].pass).toBe(true);
+    expect(result.layers[0].score).toBe(100);
+    expect(result.timestamp).toBeTruthy();
+    expect(result.summary).toContain('PASS');
+  });
+
+  it('returns block decision when deterministic layer fails', async () => {
+    const config: CanductorConfig = {
+      version: 1,
+      layers: {
+        failing_test: {
+          name: 'failing_test',
+          type: 'deterministic',
+          run: 'exit 1',
+          weight: 1.0,
+        },
+      },
+      policy: {
+        auto_merge: 'all_pass',
+        human_review: 'any_agent_review_fail',
+        block: 'any_deterministic_fail',
+      },
+    };
+
+    const result = await verify('fail-ref', config);
+
+    expect(result.composite_score).toBe(0);
+    expect(result.decision).toBe('block');
+    expect(result.layers[0].pass).toBe(false);
+    expect(result.summary).toContain('FAIL');
+  });
+
+  it('computes correct weighted average with multiple layers', async () => {
+    const config: CanductorConfig = {
+      version: 1,
+      layers: {
+        pass_layer: {
+          name: 'pass_layer',
+          type: 'deterministic',
+          run: 'echo ok',
+          weight: 1.0,
+        },
+        another_pass: {
+          name: 'another_pass',
+          type: 'deterministic',
+          run: 'echo fine',
+          weight: 0.5,
+        },
+      },
+      policy: {
+        auto_merge: 'all_pass',
+        human_review: 'any_agent_review_fail',
+        block: 'any_deterministic_fail',
+      },
+    };
+
+    const result = await verify('multi-ref', config);
+
+    // Both pass with 100, so weighted average = (100*1.0 + 100*0.5) / (1.0+0.5) = 100
+    expect(result.composite_score).toBe(100);
+    expect(result.decision).toBe('auto_merge');
+    expect(result.layers).toHaveLength(2);
+  });
+
+  it('incorporates selfReviewResults into agent-review layers', async () => {
+    const config: CanductorConfig = {
+      version: 1,
+      layers: {
+        tests: {
+          name: 'tests',
+          type: 'deterministic',
+          run: 'echo ok',
+          weight: 1.0,
+        },
+        code_quality: {
+          name: 'code_quality',
+          type: 'agent-review',
+          rubric: '/some/rubric.md',
+          weight: 0.6,
+        },
+      },
+      policy: {
+        auto_merge: 'all_pass',
+        human_review: 'any_agent_review_fail',
+        block: 'any_deterministic_fail',
+      },
+    };
+
+    const selfReviewResults: Record<string, AgentReviewResult> = {
+      code_quality: {
+        pass: true,
+        score: 85,
+        issues: [],
+        summary: 'Solid code',
+      },
+    };
+
+    const result = await verify('review-ref', config, selfReviewResults);
+
+    // tests: 100*1.0=100, code_quality: 85*0.6=51 → (100+51)/(1.0+0.6) = 94.375 → 94
+    expect(result.composite_score).toBe(94);
+    expect(result.decision).toBe('auto_merge');
+    expect(result.layers).toHaveLength(2);
+
+    const reviewLayer = result.layers.find(l => l.name === 'code_quality');
+    expect(reviewLayer).toBeDefined();
+    expect(reviewLayer!.score).toBe(85);
+    expect(reviewLayer!.type).toBe('agent-review');
+  });
+
+  it('produces human_review when agent-review fails via selfReviewResults', async () => {
+    const config: CanductorConfig = {
+      version: 1,
+      layers: {
+        tests: {
+          name: 'tests',
+          type: 'deterministic',
+          run: 'echo ok',
+          weight: 1.0,
+        },
+        code_quality: {
+          name: 'code_quality',
+          type: 'agent-review',
+          rubric: '/some/rubric.md',
+          weight: 0.6,
+        },
+      },
+      policy: {
+        auto_merge: 'all_pass',
+        human_review: 'any_agent_review_fail',
+        block: 'any_deterministic_fail',
+      },
+    };
+
+    const selfReviewResults: Record<string, AgentReviewResult> = {
+      code_quality: {
+        pass: false,
+        score: 40,
+        issues: [{ severity: 'critical', description: 'Uses any types' }],
+        summary: 'Poor quality',
+      },
+    };
+
+    const result = await verify('bad-ref', config, selfReviewResults);
+
+    expect(result.decision).toBe('human_review');
+
+    const reviewLayer = result.layers.find(l => l.name === 'code_quality');
+    expect(reviewLayer!.pass).toBe(false);
+    expect(reviewLayer!.score).toBe(40);
   });
 });


### PR DESCRIPTION
Closes #23 — implemented autonomously by canductor pipeline.

5 integration tests for the `verify()` orchestrator:
- Single passing deterministic layer → auto_merge
- Failing deterministic layer → block decision
- Multiple layers with correct weighted average computation
- `selfReviewResults` injection into agent-review layers
- Failing agent-review producing human_review decision

Canductor score: 98/100 (auto_merge)