### PR TITLE
Story: Detect project toolchain and generate matching config

### DIFF
--- a/.canductor/results.tsv
+++ b/.canductor/results.tsv
@@ -6,3 +6,4 @@ pipeline-migration	2026-03-23T18:17:24.970Z	77	auto_merge	typecheck:100,tests:10
 23	2026-03-23T19:12:22.712Z	98	auto_merge	typecheck:100,tests:100,code_quality:93	pending	Verified 23
 28	2026-03-23T20:07:04.195Z	99	auto_merge	typecheck:100,tests:100,code_quality:95	merged	Verified 28
 29	2026-03-23T21:06:36.729Z	99	auto_merge	typecheck:100,tests:100,code_quality:95	pending	Verified 29
+32	2026-03-23T22:23:37.583Z	99	auto_merge	typecheck:100,tests:100,code_quality:95	pending	Verified 32

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -31,6 +31,7 @@ import {
   getBaseline,
   getAgentReviewPrompt,
   parseReviewJson,
+  detectToolchain,
 } from '@canductor/core';
 import type { AgentReviewResult } from '@canductor/core';
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
@@ -74,6 +75,8 @@ function cmdInit(): void {
     return;
   }
 
+  const toolchain = detectToolchain(repoRoot);
+
   writeFileSync(configPath, `# canductor verification config
 # Docs: https://canductor.ai/docs/config
 version: 1
@@ -82,13 +85,13 @@ layers:
   tests:
     name: tests
     type: deterministic
-    run: "npm test"
+    run: "${toolchain.testCmd}"
     weight: 1.0
 
   typecheck:
     name: typecheck
     type: deterministic
-    run: "npx tsc --noEmit"
+    run: "${toolchain.typecheckCmd}"
     weight: 1.0
 
   # Uncomment to add visual regression:
@@ -115,6 +118,7 @@ policy:
   block: "any_deterministic_fail"
 `);
 
+  console.log(`Detected toolchain: ${toolchain.packageManager}`);
   console.log('Created .canductor/config.yaml');
   console.log('Edit the config to match your project, then run: canductor verify');
 }

--- a/packages/core/__tests__/scaffold.test.ts
+++ b/packages/core/__tests__/scaffold.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { detectToolchain } from '../src/scaffold.js';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'canductor-scaffold-'));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function writePackageJson(scripts: Record<string, string>): void {
+  writeFileSync(join(tempDir, 'package.json'), JSON.stringify({ scripts }));
+}
+
+function writeLockFile(name: string): void {
+  writeFileSync(join(tempDir, name), '');
+}
+
+// ---------------------------------------------------------------------------
+// detectToolchain
+// ---------------------------------------------------------------------------
+describe('detectToolchain', () => {
+  it('detects pnpm project with all scripts', () => {
+    writeLockFile('pnpm-lock.yaml');
+    writePackageJson({ test: 'vitest', typecheck: 'tsc --noEmit', build: 'tsc' });
+
+    const result = detectToolchain(tempDir);
+
+    expect(result.packageManager).toBe('pnpm');
+    expect(result.testCmd).toBe('pnpm test');
+    expect(result.typecheckCmd).toBe('pnpm typecheck');
+    expect(result.buildCmd).toBe('pnpm build');
+  });
+
+  it('detects yarn project', () => {
+    writeLockFile('yarn.lock');
+    writePackageJson({ test: 'jest' });
+
+    const result = detectToolchain(tempDir);
+
+    expect(result.packageManager).toBe('yarn');
+    expect(result.testCmd).toBe('yarn test');
+  });
+
+  it('detects npm project when no lock file exists', () => {
+    writePackageJson({ test: 'jest' });
+
+    const result = detectToolchain(tempDir);
+
+    expect(result.packageManager).toBe('npm');
+    expect(result.testCmd).toBe('npm run test');
+  });
+
+  it('falls back to defaults when scripts are missing', () => {
+    writeLockFile('pnpm-lock.yaml');
+    writePackageJson({});
+
+    const result = detectToolchain(tempDir);
+
+    expect(result.packageManager).toBe('pnpm');
+    expect(result.testCmd).toBe('npm test');
+    expect(result.typecheckCmd).toBe('npx tsc --noEmit');
+    expect(result.buildCmd).toBeNull();
+  });
+
+  it('handles missing package.json', () => {
+    const result = detectToolchain(tempDir);
+
+    expect(result.packageManager).toBe('npm');
+    expect(result.testCmd).toBe('npm test');
+    expect(result.typecheckCmd).toBe('npx tsc --noEmit');
+    expect(result.buildCmd).toBeNull();
+  });
+
+  it('handles malformed package.json', () => {
+    writeFileSync(join(tempDir, 'package.json'), 'not valid json');
+
+    const result = detectToolchain(tempDir);
+
+    expect(result.packageManager).toBe('npm');
+    expect(result.testCmd).toBe('npm test');
+    expect(result.typecheckCmd).toBe('npx tsc --noEmit');
+    expect(result.buildCmd).toBeNull();
+  });
+
+  it('prefers pnpm over yarn when both lock files exist', () => {
+    writeLockFile('pnpm-lock.yaml');
+    writeLockFile('yarn.lock');
+    writePackageJson({ test: 'vitest' });
+
+    const result = detectToolchain(tempDir);
+
+    expect(result.packageManager).toBe('pnpm');
+  });
+
+  it('returns null buildCmd when no build script exists', () => {
+    writePackageJson({ test: 'vitest', typecheck: 'tsc' });
+
+    const result = detectToolchain(tempDir);
+
+    expect(result.buildCmd).toBeNull();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export { evaluateExpression, evaluateAllPolicies, buildPolicyContext } from './p
 export type { PolicyContext } from './policy.js';
 export { runAgentReview, buildReviewPrompt, parseReviewJson } from './agent-review.js';
 export { injectContext, suggestRuleImprovements } from './feedback.js';
+export { detectToolchain } from './scaffold.js';
 export type {
   CanductorConfig,
   LayerConfig,
@@ -20,4 +21,5 @@ export type {
   AgentReviewResult,
   SelfReviewPrompt,
   RuleImprovement,
+  ProjectToolchain,
 } from './types.js';

--- a/packages/core/src/scaffold.ts
+++ b/packages/core/src/scaffold.ts
@@ -1,0 +1,74 @@
+/**
+ * Scaffold — project toolchain detection for canductor init.
+ *
+ * Reads the project's package.json and lock files to determine the correct
+ * package manager, test command, typecheck command, and build command.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { ProjectToolchain } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect the project's toolchain by inspecting lock files and package.json.
+ *
+ * @param repoRoot - Absolute path to the repository root
+ * @returns Detected toolchain with package manager and commands
+ */
+export function detectToolchain(repoRoot: string): ProjectToolchain {
+  const packageManager = detectPackageManager(repoRoot);
+  const scripts = readPackageScripts(repoRoot);
+
+  const runPrefix = packageManager === 'npm' ? 'npm run' : packageManager;
+
+  const testCmd = scripts.test
+    ? `${runPrefix} test`
+    : `npm test`;
+
+  const typecheckCmd = scripts.typecheck
+    ? `${runPrefix} typecheck`
+    : 'npx tsc --noEmit';
+
+  const buildCmd = scripts.build
+    ? `${runPrefix} build`
+    : null;
+
+  return { packageManager, testCmd, typecheckCmd, buildCmd };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function detectPackageManager(repoRoot: string): ProjectToolchain['packageManager'] {
+  if (existsSync(join(repoRoot, 'pnpm-lock.yaml'))) return 'pnpm';
+  if (existsSync(join(repoRoot, 'yarn.lock'))) return 'yarn';
+  return 'npm';
+}
+
+interface PackageScripts {
+  test?: string;
+  typecheck?: string;
+  build?: string;
+}
+
+function readPackageScripts(repoRoot: string): PackageScripts {
+  const pkgPath = join(repoRoot, 'package.json');
+  if (!existsSync(pkgPath)) return {};
+
+  try {
+    const content = readFileSync(pkgPath, 'utf-8');
+    const pkg: { scripts?: Record<string, string> } = JSON.parse(content);
+    return {
+      test: pkg.scripts?.test,
+      typecheck: pkg.scripts?.typecheck,
+      build: pkg.scripts?.build,
+    };
+  } catch {
+    return {};
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -105,6 +105,14 @@ export interface RuleImprovement {
   confidence: number; // 0-1, based on how many times the pattern was seen
 }
 
+/** Detected project toolchain from package.json and lock files. */
+export interface ProjectToolchain {
+  packageManager: 'pnpm' | 'npm' | 'yarn';
+  testCmd: string;
+  typecheckCmd: string;
+  buildCmd: string | null;
+}
+
 /** Context injected into agent prompts based on results history. */
 export interface QualityContext {
   /** Recent results summary. */


### PR DESCRIPTION
Closes #32 — implemented autonomously by canductor pipeline.

## Changes
- Added `detectToolchain(repoRoot)` to `packages/core/src/scaffold.ts` — detects package manager (pnpm/npm/yarn) from lock files and reads test/typecheck/build scripts from package.json
- Added `ProjectToolchain` type to `types.ts`
- Updated `cmdInit()` in CLI to use detected toolchain instead of hardcoded `npm test` / `npx tsc --noEmit`
- 8 tests covering pnpm/yarn/npm detection, missing scripts fallback, malformed package.json, missing package.json

## Verification
- Canductor score: 99/100 (auto_merge)
- All 202 tests pass
- TypeScript strict mode clean