### PR TITLE
Story: Scaffold a starter code-quality rubric from init

### DIFF
--- a/.canductor/results.tsv
+++ b/.canductor/results.tsv
@@ -7,3 +7,4 @@ pipeline-migration	2026-03-23T18:17:24.970Z	77	auto_merge	typecheck:100,tests:10
 28	2026-03-23T20:07:04.195Z	99	auto_merge	typecheck:100,tests:100,code_quality:95	merged	Verified 28
 29	2026-03-23T21:06:36.729Z	99	auto_merge	typecheck:100,tests:100,code_quality:95	pending	Verified 29
 32	2026-03-23T22:23:37.583Z	99	auto_merge	typecheck:100,tests:100,code_quality:95	pending	Verified 32
+33	2026-03-23T22:26:15.515Z	99	auto_merge	typecheck:100,tests:100,code_quality:95	pending	Verified 33

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -32,6 +32,7 @@ import {
   getAgentReviewPrompt,
   parseReviewJson,
   detectToolchain,
+  scaffoldRubric,
 } from '@canductor/core';
 import type { AgentReviewResult } from '@canductor/core';
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
@@ -77,6 +78,19 @@ function cmdInit(): void {
 
   const toolchain = detectToolchain(repoRoot);
 
+  const rubricCreated = scaffoldRubric(repoRoot);
+  const agentReviewSection = rubricCreated
+    ? `
+  code_quality:
+    name: code_quality
+    type: agent-review
+    model: claude-sonnet-4-6
+    rubric: ".canductor/rubrics/code-quality.md"
+    context: ["src/"]
+    weight: 0.6
+`
+    : '';
+
   writeFileSync(configPath, `# canductor verification config
 # Docs: https://canductor.ai/docs/config
 version: 1
@@ -93,7 +107,7 @@ layers:
     type: deterministic
     run: "${toolchain.typecheckCmd}"
     weight: 1.0
-
+${agentReviewSection}
   # Uncomment to add visual regression:
   # visual:
   #   name: visual
@@ -103,15 +117,6 @@ layers:
   #   threshold: 5
   #   weight: 0.8
 
-  # Uncomment to add AI-powered review:
-  # ux_review:
-  #   name: ux_review
-  #   type: agent-review
-  #   model: claude-sonnet-4-6
-  #   rubric: ".claude/rubrics/ux.md"
-  #   context: ["src/", "docs/design-system.md"]
-  #   weight: 0.6
-
 policy:
   auto_merge: "all_deterministic_pass AND all_pass"
   human_review: "any_agent_review_fail"
@@ -120,6 +125,9 @@ policy:
 
   console.log(`Detected toolchain: ${toolchain.packageManager}`);
   console.log('Created .canductor/config.yaml');
+  if (rubricCreated) {
+    console.log('Created .canductor/rubrics/code-quality.md');
+  }
   console.log('Edit the config to match your project, then run: canductor verify');
 }
 

--- a/packages/core/__tests__/scaffold.test.ts
+++ b/packages/core/__tests__/scaffold.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { detectToolchain } from '../src/scaffold.js';
+import { detectToolchain, scaffoldRubric } from '../src/scaffold.js';
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -109,5 +109,52 @@ describe('detectToolchain', () => {
     const result = detectToolchain(tempDir);
 
     expect(result.buildCmd).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scaffoldRubric
+// ---------------------------------------------------------------------------
+describe('scaffoldRubric', () => {
+  it('creates rubric file and returns true', () => {
+    const result = scaffoldRubric(tempDir);
+
+    expect(result).toBe(true);
+    const rubricPath = join(tempDir, '.canductor', 'rubrics', 'code-quality.md');
+    expect(existsSync(rubricPath)).toBe(true);
+  });
+
+  it('rubric content follows template structure with weighted categories', () => {
+    scaffoldRubric(tempDir);
+
+    const content = readFileSync(
+      join(tempDir, '.canductor', 'rubrics', 'code-quality.md'),
+      'utf-8',
+    );
+    expect(content).toContain('# Code Quality Rubric');
+    expect(content).toContain('weight: 30%');
+    expect(content).toContain('weight: 20%');
+
+    // Verify weights sum to 100%
+    const weights = [...content.matchAll(/weight:\s*(\d+)%/g)].map(m => Number(m[1]));
+    expect(weights.reduce((a, b) => a + b, 0)).toBe(100);
+  });
+
+  it('does not overwrite existing rubric and returns false', () => {
+    const rubricDir = join(tempDir, '.canductor', 'rubrics');
+    mkdirSync(rubricDir, { recursive: true });
+    const rubricPath = join(rubricDir, 'code-quality.md');
+    writeFileSync(rubricPath, '# Custom rubric');
+
+    const result = scaffoldRubric(tempDir);
+
+    expect(result).toBe(false);
+    expect(readFileSync(rubricPath, 'utf-8')).toBe('# Custom rubric');
+  });
+
+  it('creates nested directories if they do not exist', () => {
+    scaffoldRubric(tempDir);
+
+    expect(existsSync(join(tempDir, '.canductor', 'rubrics'))).toBe(true);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,7 @@ export { evaluateExpression, evaluateAllPolicies, buildPolicyContext } from './p
 export type { PolicyContext } from './policy.js';
 export { runAgentReview, buildReviewPrompt, parseReviewJson } from './agent-review.js';
 export { injectContext, suggestRuleImprovements } from './feedback.js';
-export { detectToolchain } from './scaffold.js';
+export { detectToolchain, scaffoldRubric } from './scaffold.js';
 export type {
   CanductorConfig,
   LayerConfig,

--- a/packages/core/src/scaffold.ts
+++ b/packages/core/src/scaffold.ts
@@ -1,11 +1,12 @@
 /**
- * Scaffold — project toolchain detection for canductor init.
+ * Scaffold — project toolchain detection and starter rubric for canductor init.
  *
  * Reads the project's package.json and lock files to determine the correct
  * package manager, test command, typecheck command, and build command.
+ * Also scaffolds a starter code-quality rubric.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import type { ProjectToolchain } from './types.js';
 
@@ -39,6 +40,57 @@ export function detectToolchain(repoRoot: string): ProjectToolchain {
 
   return { packageManager, testCmd, typecheckCmd, buildCmd };
 }
+
+/**
+ * Scaffold a starter code-quality rubric at .canductor/rubrics/code-quality.md.
+ *
+ * @param repoRoot - Absolute path to the repository root
+ * @returns true if the rubric was created, false if it already exists
+ */
+export function scaffoldRubric(repoRoot: string): boolean {
+  const rubricDir = join(repoRoot, '.canductor', 'rubrics');
+  const rubricPath = join(rubricDir, 'code-quality.md');
+
+  if (existsSync(rubricPath)) return false;
+
+  if (!existsSync(rubricDir)) mkdirSync(rubricDir, { recursive: true });
+
+  writeFileSync(rubricPath, STARTER_RUBRIC);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const STARTER_RUBRIC = `# Code Quality Rubric
+
+Evaluate TypeScript source code against these criteria. Score each 0-100 and flag issues.
+
+## Architecture (weight: 30%)
+- Functions are small and single-purpose
+- Dependencies flow in one direction (no circular imports)
+- Types are precise (no \`any\`, no loose unions)
+- Errors are handled explicitly, not swallowed
+
+## Testing (weight: 30%)
+- New functions have corresponding tests
+- Tests cover the happy path AND at least one error path
+- Mocks are minimal — prefer testing real logic
+- No snapshot tests (use inline assertions)
+
+## Code Style (weight: 20%)
+- TypeScript strict mode passes
+- No unused imports or variables
+- Consistent naming conventions
+- Comments explain WHY, not WHAT
+
+## Error Handling (weight: 20%)
+- External inputs are validated at system boundaries
+- Errors include descriptive messages
+- No silent failures (catch blocks that swallow errors)
+- Async operations handle rejection paths
+`;
 
 // ---------------------------------------------------------------------------
 // Internal helpers


### PR DESCRIPTION
Closes #33 — implemented autonomously by canductor pipeline.

## Changes
- Added `scaffoldRubric(repoRoot)` to `scaffold.ts` — creates `.canductor/rubrics/code-quality.md` with a starter rubric (4 categories, weights sum to 100%)
- Does not overwrite existing rubric files
- `cmdInit()` now calls `scaffoldRubric()` and adds a `code_quality` agent-review layer to the generated config
- 4 new tests for rubric scaffolding (creation, template structure, no-overwrite, directory creation)

## Verification
- Canductor score: 99/100 (auto_merge)
- All 206 tests pass
- TypeScript strict mode clean