### PR TITLE
Story: Run first verification after init and log baseline result

### DIFF
--- a/.canductor/results.tsv
+++ b/.canductor/results.tsv
@@ -8,3 +8,4 @@ pipeline-migration	2026-03-23T18:17:24.970Z	77	auto_merge	typecheck:100,tests:10
 29	2026-03-23T21:06:36.729Z	99	auto_merge	typecheck:100,tests:100,code_quality:95	pending	Verified 29
 32	2026-03-23T22:23:37.583Z	99	auto_merge	typecheck:100,tests:100,code_quality:95	pending	Verified 32
 33	2026-03-23T22:26:15.515Z	99	auto_merge	typecheck:100,tests:100,code_quality:95	pending	Verified 33
+34	2026-03-23T22:30:12.428Z	99	auto_merge	typecheck:100,tests:100,code_quality:94	pending	Verified 34

--- a/packages/cli/__tests__/cli.test.ts
+++ b/packages/cli/__tests__/cli.test.ts
@@ -85,11 +85,15 @@ describe('canductor init', () => {
   });
 
   it('creates config file in target directory', () => {
+    // Provide a package.json so init generates fast commands for first verification
+    writeFileSync(join(initDir, 'package.json'), JSON.stringify({
+      scripts: { test: 'echo ok', typecheck: 'echo ok' },
+    }));
     const { stdout, exitCode } = runCli('init', initDir);
     expect(exitCode).toBe(0);
     expect(stdout).toContain('Created .canductor/config.yaml');
     expect(existsSync(join(initDir, '.canductor', 'config.yaml'))).toBe(true);
-  });
+  }, 15000);
 
   it('reports existing config without overwriting', () => {
     setupConfig(initDir);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -33,6 +33,7 @@ import {
   parseReviewJson,
   detectToolchain,
   scaffoldRubric,
+  runFirstVerification,
 } from '@canductor/core';
 import type { AgentReviewResult } from '@canductor/core';
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
@@ -66,7 +67,7 @@ Usage:
 `);
 }
 
-function cmdInit(): void {
+async function cmdInit(): Promise<void> {
   const dir = join(repoRoot, '.canductor');
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 
@@ -128,7 +129,14 @@ policy:
   if (rubricCreated) {
     console.log('Created .canductor/rubrics/code-quality.md');
   }
-  console.log('Edit the config to match your project, then run: canductor verify');
+
+  const result = await runFirstVerification(repoRoot);
+  if (result) {
+    console.log(`Initial verification score: ${result.composite_score}/100 (${result.decision})`);
+    console.log(`Baseline set to ${result.composite_score}`);
+  } else {
+    console.log('Warning: initial verification could not run. Run manually: canductor verify');
+  }
 }
 
 async function cmdVerify(): Promise<void> {
@@ -481,7 +489,7 @@ async function main(): Promise<void> {
       cmdSuggest();
       break;
     case 'init':
-      cmdInit();
+      await cmdInit();
       break;
     case 'help':
     case '--help':

--- a/packages/core/__tests__/scaffold.test.ts
+++ b/packages/core/__tests__/scaffold.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { detectToolchain, scaffoldRubric } from '../src/scaffold.js';
+import { detectToolchain, scaffoldRubric, runFirstVerification } from '../src/scaffold.js';
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -156,5 +156,87 @@ describe('scaffoldRubric', () => {
     scaffoldRubric(tempDir);
 
     expect(existsSync(join(tempDir, '.canductor', 'rubrics'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runFirstVerification
+// ---------------------------------------------------------------------------
+
+function writeConfig(dir: string, content: string): void {
+  const configDir = join(dir, '.canductor');
+  if (!existsSync(configDir)) mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, 'config.yaml'), content);
+}
+
+describe('runFirstVerification', () => {
+  it('runs verification and returns result with score', async () => {
+    writeConfig(tempDir, `version: 1
+layers:
+  check:
+    name: check
+    type: deterministic
+    run: "echo ok"
+    weight: 1.0
+policy:
+  auto_merge: "all_deterministic_pass"
+  human_review: "false"
+  block: "any_deterministic_fail"
+`);
+
+    const result = await runFirstVerification(tempDir);
+
+    expect(result).not.toBeNull();
+    expect(result!.composite_score).toBe(100);
+    expect(result!.ref).toBe('init');
+  });
+
+  it('appends result to results.tsv', async () => {
+    writeConfig(tempDir, `version: 1
+layers:
+  check:
+    name: check
+    type: deterministic
+    run: "echo ok"
+    weight: 1.0
+policy:
+  auto_merge: "all_deterministic_pass"
+  human_review: "false"
+  block: "any_deterministic_fail"
+`);
+
+    await runFirstVerification(tempDir);
+
+    const resultsPath = join(tempDir, '.canductor', 'results.tsv');
+    expect(existsSync(resultsPath)).toBe(true);
+    const content = readFileSync(resultsPath, 'utf-8');
+    expect(content).toContain('init');
+    expect(content).toContain('Initial setup');
+  });
+
+  it('sets baseline in config', async () => {
+    writeConfig(tempDir, `version: 1
+layers:
+  check:
+    name: check
+    type: deterministic
+    run: "echo ok"
+    weight: 1.0
+policy:
+  auto_merge: "all_deterministic_pass"
+  human_review: "false"
+  block: "any_deterministic_fail"
+`);
+
+    await runFirstVerification(tempDir);
+
+    const configContent = readFileSync(join(tempDir, '.canductor', 'config.yaml'), 'utf-8');
+    expect(configContent).toContain('baseline: 100');
+  });
+
+  it('returns null when config does not exist', async () => {
+    const result = await runFirstVerification(tempDir);
+
+    expect(result).toBeNull();
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,7 @@ export { evaluateExpression, evaluateAllPolicies, buildPolicyContext } from './p
 export type { PolicyContext } from './policy.js';
 export { runAgentReview, buildReviewPrompt, parseReviewJson } from './agent-review.js';
 export { injectContext, suggestRuleImprovements } from './feedback.js';
-export { detectToolchain, scaffoldRubric } from './scaffold.js';
+export { detectToolchain, scaffoldRubric, runFirstVerification } from './scaffold.js';
 export type {
   CanductorConfig,
   LayerConfig,

--- a/packages/core/src/scaffold.ts
+++ b/packages/core/src/scaffold.ts
@@ -8,7 +8,10 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
-import type { ProjectToolchain } from './types.js';
+import { loadConfig, writeConfigBaseline } from './config.js';
+import { verify } from './verify.js';
+import { appendResult } from './results.js';
+import type { ProjectToolchain, VerifyResult } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -57,6 +60,30 @@ export function scaffoldRubric(repoRoot: string): boolean {
 
   writeFileSync(rubricPath, STARTER_RUBRIC);
   return true;
+}
+
+/**
+ * Run a first verification after init and log the baseline result.
+ *
+ * Loads the newly created config, runs verify, appends the result to
+ * results.tsv, and sets the baseline score. If verification fails,
+ * returns null instead of throwing.
+ *
+ * @param repoRoot - Absolute path to the repository root
+ * @returns The verify result, or null if verification could not run
+ */
+export async function runFirstVerification(repoRoot: string): Promise<VerifyResult | null> {
+  try {
+    const config = loadConfig(repoRoot);
+    const result = await verify('init', config);
+
+    appendResult(repoRoot, result, 'merged', 'Initial setup');
+    writeConfigBaseline(repoRoot, result.composite_score);
+
+    return result;
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #34 — implemented autonomously by canductor pipeline.

## Changes
- Added `runFirstVerification(repoRoot)` to `scaffold.ts` — runs verify('init', config), appends result to results.tsv, sets baseline
- Gracefully returns null if verification fails (no API key, commands fail, etc.)
- `cmdInit()` calls it as final step, prints initial score
- 4 new tests: successful verification, results.tsv created, baseline written, graceful failure
- Updated CLI init test to provide package.json with fast commands

## Verification
- Canductor score: 99/100 (auto_merge)
- All 210 tests pass
- TypeScript strict mode clean