### PR TITLE
Story: Add YAML frontmatter parsing and validation for SKILL.md files

### DIFF
--- a/.canductor/results.tsv
+++ b/.canductor/results.tsv
@@ -9,3 +9,4 @@ pipeline-migration	2026-03-23T18:17:24.970Z	77	auto_merge	typecheck:100,tests:10
 32	2026-03-23T22:23:37.583Z	99	auto_merge	typecheck:100,tests:100,code_quality:95	pending	Verified 32
 33	2026-03-23T22:26:15.515Z	99	auto_merge	typecheck:100,tests:100,code_quality:95	pending	Verified 33
 34	2026-03-23T22:30:12.428Z	99	auto_merge	typecheck:100,tests:100,code_quality:94	pending	Verified 34
+38	2026-03-23T22:33:21.722Z	99	auto_merge	typecheck:100,tests:100,code_quality:95	pending	Verified 38

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -34,6 +34,7 @@ import {
   detectToolchain,
   scaffoldRubric,
   runFirstVerification,
+  lintSkills,
 } from '@canductor/core';
 import type { AgentReviewResult } from '@canductor/core';
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
@@ -63,6 +64,7 @@ Usage:
   canductor inject <file>                    Inject quality context into a file (e.g. CLAUDE.md)
   canductor suggest                          Suggest rule improvements based on history
   canductor init                             Create starter config
+  canductor skill-lint                       Validate SKILL.md frontmatter
   canductor help                             Show this message
 `);
 }
@@ -453,6 +455,31 @@ function cmdSuggest(): void {
   }
 }
 
+function cmdSkillLint(): void {
+  const results = lintSkills(repoRoot);
+
+  if (results.length === 0) {
+    console.log('No SKILL.md files found under .claude/skills/');
+    return;
+  }
+
+  let hasErrors = false;
+  for (const result of results) {
+    const status = result.valid ? 'PASS' : 'FAIL';
+    console.log(`  ${status} ${result.path}`);
+    for (const error of result.errors) {
+      console.log(`       ${error}`);
+    }
+    if (!result.valid) hasErrors = true;
+  }
+
+  console.log(`\n${results.length} skill(s) checked, ${results.filter(r => !r.valid).length} error(s)`);
+
+  if (hasErrors) {
+    process.exit(1);
+  }
+}
+
 async function main(): Promise<void> {
   switch (command) {
     case 'verify':
@@ -490,6 +517,9 @@ async function main(): Promise<void> {
       break;
     case 'init':
       await cmdInit();
+      break;
+    case 'skill-lint':
+      cmdSkillLint();
       break;
     case 'help':
     case '--help':

--- a/packages/core/__tests__/skill-lint.test.ts
+++ b/packages/core/__tests__/skill-lint.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  parseSkillFrontmatter,
+  validateSkillFrontmatter,
+  discoverSkills,
+  lintSkills,
+} from '../src/skill-lint.js';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'canductor-skill-lint-'));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function writeSkill(relativePath: string, content: string): void {
+  const fullPath = join(tempDir, relativePath);
+  mkdirSync(join(fullPath, '..'), { recursive: true });
+  writeFileSync(fullPath, content);
+}
+
+// ---------------------------------------------------------------------------
+// parseSkillFrontmatter
+// ---------------------------------------------------------------------------
+describe('parseSkillFrontmatter', () => {
+  it('parses valid frontmatter with all fields', () => {
+    const content = `---
+name: pipeline
+description: Autonomous story pipeline
+argument-hint: "[--issue N]"
+---
+
+# Pipeline`;
+
+    const result = parseSkillFrontmatter(content);
+
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe('pipeline');
+    expect(result!.description).toBe('Autonomous story pipeline');
+    expect(result!['argument-hint']).toBe('[--issue N]');
+  });
+
+  it('returns null when no frontmatter found', () => {
+    const result = parseSkillFrontmatter('# No frontmatter here');
+
+    expect(result).toBeNull();
+  });
+
+  it('parses tags as array', () => {
+    const content = `---
+name: test
+description: Test skill
+tags: [quality, lint]
+---`;
+
+    const result = parseSkillFrontmatter(content);
+
+    expect(result!.tags).toEqual(['quality', 'lint']);
+  });
+
+  it('handles quoted values', () => {
+    const content = `---
+name: "my-skill"
+description: 'A quoted description'
+---`;
+
+    const result = parseSkillFrontmatter(content);
+
+    expect(result!.name).toBe('my-skill');
+    expect(result!.description).toBe('A quoted description');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateSkillFrontmatter
+// ---------------------------------------------------------------------------
+describe('validateSkillFrontmatter', () => {
+  it('returns no errors for valid frontmatter', () => {
+    const errors = validateSkillFrontmatter({
+      name: 'pipeline',
+      description: 'A skill',
+    });
+
+    expect(errors).toEqual([]);
+  });
+
+  it('returns error for missing name', () => {
+    const errors = validateSkillFrontmatter({
+      description: 'A skill',
+    });
+
+    expect(errors).toContain('Missing required field: name');
+  });
+
+  it('returns error for missing description', () => {
+    const errors = validateSkillFrontmatter({
+      name: 'pipeline',
+    });
+
+    expect(errors).toContain('Missing required field: description');
+  });
+
+  it('returns errors for both missing fields', () => {
+    const errors = validateSkillFrontmatter({});
+
+    expect(errors).toHaveLength(2);
+  });
+
+  it('returns error for empty name', () => {
+    const errors = validateSkillFrontmatter({
+      name: '  ',
+      description: 'A skill',
+    });
+
+    expect(errors).toContain('Missing required field: name');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverSkills
+// ---------------------------------------------------------------------------
+describe('discoverSkills', () => {
+  it('finds SKILL.md files under .claude/skills/', () => {
+    writeSkill('.claude/skills/pipeline/SKILL.md', '---\nname: pipeline\n---');
+    writeSkill('.claude/skills/verify/SKILL.md', '---\nname: verify\n---');
+
+    const paths = discoverSkills(tempDir);
+
+    expect(paths).toHaveLength(2);
+    expect(paths[0]).toContain('pipeline');
+    expect(paths[1]).toContain('verify');
+  });
+
+  it('returns empty array when .claude/skills/ does not exist', () => {
+    const paths = discoverSkills(tempDir);
+
+    expect(paths).toEqual([]);
+  });
+
+  it('ignores non-SKILL.md files', () => {
+    writeSkill('.claude/skills/pipeline/SKILL.md', '---\nname: p\n---');
+    writeSkill('.claude/skills/pipeline/README.md', '# readme');
+
+    const paths = discoverSkills(tempDir);
+
+    expect(paths).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lintSkills
+// ---------------------------------------------------------------------------
+describe('lintSkills', () => {
+  it('returns valid result for well-formed skills', () => {
+    writeSkill('.claude/skills/pipeline/SKILL.md', `---
+name: pipeline
+description: Autonomous pipeline
+---
+# Pipeline`);
+
+    const results = lintSkills(tempDir);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].valid).toBe(true);
+    expect(results[0].errors).toEqual([]);
+    expect(results[0].path).toBe('.claude/skills/pipeline/SKILL.md');
+  });
+
+  it('returns invalid result for missing frontmatter', () => {
+    writeSkill('.claude/skills/bad/SKILL.md', '# No frontmatter');
+
+    const results = lintSkills(tempDir);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].valid).toBe(false);
+    expect(results[0].errors).toContain('No YAML frontmatter found');
+  });
+
+  it('returns invalid result for missing required fields', () => {
+    writeSkill('.claude/skills/partial/SKILL.md', `---
+name: partial
+---
+# Partial`);
+
+    const results = lintSkills(tempDir);
+
+    expect(results[0].valid).toBe(false);
+    expect(results[0].errors).toContain('Missing required field: description');
+  });
+
+  it('returns empty array when no skills exist', () => {
+    const results = lintSkills(tempDir);
+
+    expect(results).toEqual([]);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@ export type { PolicyContext } from './policy.js';
 export { runAgentReview, buildReviewPrompt, parseReviewJson } from './agent-review.js';
 export { injectContext, suggestRuleImprovements } from './feedback.js';
 export { detectToolchain, scaffoldRubric, runFirstVerification } from './scaffold.js';
+export { parseSkillFrontmatter, validateSkillFrontmatter, discoverSkills, lintSkills } from './skill-lint.js';
 export type {
   CanductorConfig,
   LayerConfig,
@@ -22,4 +23,6 @@ export type {
   SelfReviewPrompt,
   RuleImprovement,
   ProjectToolchain,
+  SkillFrontmatter,
+  SkillLintResult,
 } from './types.js';

--- a/packages/core/src/skill-lint.ts
+++ b/packages/core/src/skill-lint.ts
@@ -1,0 +1,153 @@
+/**
+ * Skill lint — discovers, parses, and validates SKILL.md files.
+ *
+ * SKILL.md files use YAML frontmatter (--- delimited) to declare metadata.
+ * This module validates that required fields are present and well-formed.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import type { SkillFrontmatter, SkillLintResult } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse YAML frontmatter from a SKILL.md file's content.
+ *
+ * @param content - The raw file content
+ * @returns Parsed frontmatter object, or null if no frontmatter found
+ */
+export function parseSkillFrontmatter(content: string): SkillFrontmatter | null {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+
+  const raw = match[1];
+  const result: SkillFrontmatter = {};
+
+  for (const line of raw.split('\n')) {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) continue;
+
+    const key = line.slice(0, colonIdx).trim();
+    const value = line.slice(colonIdx + 1).trim();
+
+    if (key === 'name') {
+      result.name = unquote(value);
+    } else if (key === 'description') {
+      result.description = unquote(value);
+    } else if (key === 'argument-hint') {
+      result['argument-hint'] = unquote(value);
+    } else if (key === 'tags') {
+      result.tags = parseYamlArray(value);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Validate a parsed frontmatter object for required fields.
+ *
+ * @param frontmatter - Parsed frontmatter to validate
+ * @returns Array of validation error messages (empty if valid)
+ */
+export function validateSkillFrontmatter(frontmatter: SkillFrontmatter): string[] {
+  const errors: string[] = [];
+
+  if (!frontmatter.name || frontmatter.name.trim() === '') {
+    errors.push('Missing required field: name');
+  }
+  if (!frontmatter.description || frontmatter.description.trim() === '') {
+    errors.push('Missing required field: description');
+  }
+
+  return errors;
+}
+
+/**
+ * Discover all SKILL.md files under .claude/skills/.
+ *
+ * @param rootDir - Repository root directory
+ * @returns Array of absolute paths to SKILL.md files
+ */
+export function discoverSkills(rootDir: string): string[] {
+  const skillsDir = join(rootDir, '.claude', 'skills');
+  if (!existsSync(skillsDir)) return [];
+
+  const results: string[] = [];
+  walkDir(skillsDir, results);
+  return results.sort();
+}
+
+/**
+ * Lint all SKILL.md files in the repository.
+ *
+ * @param rootDir - Repository root directory
+ * @returns Array of lint results, one per SKILL.md file
+ */
+export function lintSkills(rootDir: string): SkillLintResult[] {
+  const paths = discoverSkills(rootDir);
+
+  return paths.map(skillPath => {
+    const content = readFileSync(skillPath, 'utf-8');
+    const frontmatter = parseSkillFrontmatter(content);
+    const relPath = relative(rootDir, skillPath);
+
+    if (!frontmatter) {
+      return {
+        path: relPath,
+        frontmatter: null,
+        errors: ['No YAML frontmatter found'],
+        valid: false,
+      };
+    }
+
+    const errors = validateSkillFrontmatter(frontmatter);
+    return {
+      path: relPath,
+      frontmatter,
+      errors,
+      valid: errors.length === 0,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function walkDir(dir: string, results: string[]): void {
+  const entries = readdirSync(dir);
+  for (const entry of entries) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      walkDir(fullPath, results);
+    } else if (entry === 'SKILL.md') {
+      results.push(fullPath);
+    }
+  }
+}
+
+function unquote(value: string): string {
+  if ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function parseYamlArray(value: string): string[] {
+  // Handle inline array: [a, b, c]
+  const inlineMatch = value.match(/^\[(.*)\]$/);
+  if (inlineMatch) {
+    return inlineMatch[1].split(',').map(s => unquote(s.trim())).filter(s => s !== '');
+  }
+  // Single value fallback
+  if (value.trim() !== '') {
+    return [unquote(value)];
+  }
+  return [];
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -113,6 +113,22 @@ export interface ProjectToolchain {
   buildCmd: string | null;
 }
 
+/** Parsed YAML frontmatter from a SKILL.md file. */
+export interface SkillFrontmatter {
+  name?: string;
+  description?: string;
+  'argument-hint'?: string;
+  tags?: string[];
+}
+
+/** Result of linting a single SKILL.md file. */
+export interface SkillLintResult {
+  path: string;
+  frontmatter: SkillFrontmatter | null;
+  errors: string[];
+  valid: boolean;
+}
+
 /** Context injected into agent prompts based on results history. */
 export interface QualityContext {
   /** Recent results summary. */


### PR DESCRIPTION
Closes #38 — implemented autonomously by canductor pipeline.

## Changes
- New `packages/core/src/skill-lint.ts` with 4 exported functions: `parseSkillFrontmatter`, `validateSkillFrontmatter`, `discoverSkills`, `lintSkills`
- Added `SkillFrontmatter` and `SkillLintResult` types to `types.ts`
- New CLI command `canductor skill-lint` — exits 1 if any SKILL.md has validation errors
- 16 new tests covering parsing, validation, discovery, and end-to-end linting

## Verification
- Canductor score: 99/100 (auto_merge)
- All 226 tests pass
- TypeScript strict mode clean