### PR TITLE
Story: Add guardrail layer type for pre-action pattern matching

### DIFF
--- a/.canductor/results.tsv
+++ b/.canductor/results.tsv
@@ -11,3 +11,4 @@ pipeline-migration	2026-03-23T18:17:24.970Z	77	auto_merge	typecheck:100,tests:10
 34	2026-03-23T22:30:12.428Z	99	auto_merge	typecheck:100,tests:100,code_quality:94	pending	Verified 34
 38	2026-03-23T22:33:21.722Z	99	auto_merge	typecheck:100,tests:100,code_quality:95	pending	Verified 38
 39	2026-03-23T22:37:34.687Z	99	auto_merge	typecheck:100,tests:100,code_quality:94	pending	Verified 39
+40	2026-03-23T22:41:05.895Z	99	auto_merge	typecheck:100,tests:100,code_quality:94	pending	Verified 40

--- a/packages/core/__tests__/guardrail.test.ts
+++ b/packages/core/__tests__/guardrail.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runGuardrailLayer } from '../src/guardrail.js';
+import type { LayerConfig } from '../src/types.js';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'canductor-guardrail-'));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function writeFile(relativePath: string, content: string): void {
+  const fullPath = join(tempDir, relativePath);
+  mkdirSync(join(fullPath, '..'), { recursive: true });
+  writeFileSync(fullPath, content);
+}
+
+function makeLayer(overrides?: Partial<LayerConfig>): LayerConfig {
+  return {
+    name: 'test_guardrail',
+    type: 'guardrail',
+    weight: 0.5,
+    include: ['src/**/*.ts'],
+    exclude: [],
+    patterns: [
+      { pattern: ': any', message: 'No any types' },
+    ],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// runGuardrailLayer
+// ---------------------------------------------------------------------------
+describe('runGuardrailLayer', () => {
+  it('passes when no violations found', () => {
+    writeFile('src/clean.ts', 'const x: string = "hello";\n');
+
+    const result = runGuardrailLayer(makeLayer(), tempDir);
+
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(100);
+    expect(result.errors).toBe('');
+  });
+
+  it('fails when violations found', () => {
+    writeFile('src/dirty.ts', 'const x: any = "hello";\n');
+
+    const result = runGuardrailLayer(makeLayer(), tempDir);
+
+    expect(result.pass).toBe(false);
+    expect(result.score).toBeLessThan(100);
+    expect(result.errors).toContain('No any types');
+    expect(result.errors).toContain('src/dirty.ts');
+  });
+
+  it('reports correct line numbers', () => {
+    writeFile('src/multi.ts', 'const a: string = "";\nconst b: any = 1;\nconst c: string = "";\n');
+
+    const result = runGuardrailLayer(makeLayer(), tempDir);
+
+    expect(result.errors).toContain('src/multi.ts:2');
+  });
+
+  it('excludes files matching exclude globs', () => {
+    writeFile('src/main.ts', 'const x: any = 1;\n');
+    writeFile('src/__tests__/test.ts', 'const x: any = 1;\n');
+
+    const result = runGuardrailLayer(makeLayer({
+      exclude: ['**/__tests__/**'],
+    }), tempDir);
+
+    // Only main.ts should be flagged
+    expect(result.errors).toContain('src/main.ts');
+    expect(result.errors).not.toContain('__tests__');
+  });
+
+  it('handles multiple patterns', () => {
+    writeFile('src/bad.ts', 'console.log("debug");\nconst x: any = 1;\n');
+
+    const result = runGuardrailLayer(makeLayer({
+      patterns: [
+        { pattern: ': any', message: 'No any types' },
+        { pattern: 'console\\.log', message: 'No console.log' },
+      ],
+    }), tempDir);
+
+    expect(result.pass).toBe(false);
+    expect(result.errors).toContain('No any types');
+    expect(result.errors).toContain('No console.log');
+  });
+
+  it('returns pass when no patterns configured', () => {
+    const result = runGuardrailLayer(makeLayer({ patterns: [] }), tempDir);
+
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(100);
+  });
+
+  it('returns pass when no include globs configured', () => {
+    const result = runGuardrailLayer(makeLayer({ include: [] }), tempDir);
+
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(100);
+  });
+
+  it('handles empty files gracefully', () => {
+    writeFile('src/empty.ts', '');
+
+    const result = runGuardrailLayer(makeLayer(), tempDir);
+
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(100);
+  });
+
+  it('reduces score proportionally to violation count', () => {
+    // 5 violations = score of 50
+    writeFile('src/bad.ts', Array(5).fill('const x: any = 1;').join('\n') + '\n');
+
+    const result = runGuardrailLayer(makeLayer(), tempDir);
+
+    expect(result.score).toBe(50);
+  });
+
+  it('floors score at 0 for many violations', () => {
+    writeFile('src/bad.ts', Array(15).fill('const x: any = 1;').join('\n') + '\n');
+
+    const result = runGuardrailLayer(makeLayer(), tempDir);
+
+    expect(result.score).toBe(0);
+  });
+});

--- a/packages/core/src/guardrail.ts
+++ b/packages/core/src/guardrail.ts
@@ -1,0 +1,181 @@
+/**
+ * Guardrail — pre-action pattern matching verification layer.
+ *
+ * Scans source files for forbidden patterns (regex) and reports matches
+ * as violations. Enables rules like "no `any` types" or "no console.log
+ * in production code" at verification time.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import type { LayerConfig, LayerResult, GuardrailViolation } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a guardrail layer: scan files matching include globs for forbidden patterns.
+ *
+ * @param layer - Layer configuration with include, exclude, and patterns
+ * @param repoRoot - Repository root directory for resolving globs
+ * @returns Layer result with score proportional to violation count
+ */
+export function runGuardrailLayer(layer: LayerConfig, repoRoot: string): LayerResult {
+  const start = Date.now();
+
+  if (!layer.patterns || layer.patterns.length === 0) {
+    return {
+      name: layer.name,
+      type: 'guardrail',
+      pass: true,
+      score: 100,
+      errors: 'No patterns configured',
+      duration_ms: Date.now() - start,
+    };
+  }
+
+  if (!layer.include || layer.include.length === 0) {
+    return {
+      name: layer.name,
+      type: 'guardrail',
+      pass: true,
+      score: 100,
+      errors: 'No include globs configured',
+      duration_ms: Date.now() - start,
+    };
+  }
+
+  const files = collectFiles(repoRoot, layer.include, layer.exclude ?? []);
+  const violations = scanFiles(files, layer.patterns, repoRoot);
+
+  const score = violations.length === 0
+    ? 100
+    : Math.max(0, 100 - violations.length * 10);
+
+  const errors = violations
+    .map(v => `${v.file}:${v.line} — ${v.message} (matched: "${v.match}")`)
+    .join('\n');
+
+  return {
+    name: layer.name,
+    type: 'guardrail',
+    pass: violations.length === 0,
+    score,
+    errors,
+    duration_ms: Date.now() - start,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect files matching include globs, excluding files matching exclude globs.
+ * Uses simple glob matching (supports * and ** patterns).
+ */
+function collectFiles(root: string, include: string[], exclude: string[]): string[] {
+  const results: string[] = [];
+  const allFiles: string[] = [];
+  walkDirForFiles(root, allFiles);
+
+  for (const file of allFiles) {
+    const rel = relative(root, file);
+    if (matchesAny(rel, include) && !matchesAny(rel, exclude)) {
+      results.push(file);
+    }
+  }
+
+  return results.sort();
+}
+
+function walkDirForFiles(dir: string, results: string[]): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (entry === 'node_modules' || entry === '.git') continue;
+    const fullPath = join(dir, entry);
+    try {
+      const stat = statSync(fullPath);
+      if (stat.isDirectory()) {
+        walkDirForFiles(fullPath, results);
+      } else if (stat.isFile()) {
+        results.push(fullPath);
+      }
+    } catch {
+      // Skip files we can't stat
+    }
+  }
+}
+
+/**
+ * Simple glob matcher supporting * (single segment) and ** (any depth).
+ */
+function matchesAny(filePath: string, globs: string[]): boolean {
+  return globs.some(glob => matchGlob(filePath, glob));
+}
+
+function matchGlob(filePath: string, glob: string): boolean {
+  // Convert glob to regex
+  // Handle **/ as "zero or more path segments"
+  const regexStr = glob
+    .replace(/\./g, '\\.')
+    .replace(/\*\*\//g, '(.*\\/)?')
+    .replace(/\*\*/g, '.*')
+    .replace(/\*/g, '[^/]*');
+
+  return new RegExp(`^${regexStr}$`).test(filePath);
+}
+
+/**
+ * Scan files for pattern violations.
+ */
+function scanFiles(
+  files: string[],
+  patterns: Array<{ pattern: string; message: string }>,
+  repoRoot: string
+): GuardrailViolation[] {
+  const violations: GuardrailViolation[] = [];
+
+  for (const file of files) {
+    let content: string;
+    try {
+      content = readFileSync(file, 'utf-8');
+    } catch {
+      continue; // Skip unreadable files
+    }
+
+    const lines = content.split('\n');
+    const relPath = relative(repoRoot, file);
+
+    for (const { pattern, message } of patterns) {
+      let regex: RegExp;
+      try {
+        regex = new RegExp(pattern, 'g');
+      } catch {
+        continue; // Skip invalid regex
+      }
+
+      for (let i = 0; i < lines.length; i++) {
+        const lineMatches = lines[i].match(regex);
+        if (lineMatches) {
+          violations.push({
+            file: relPath,
+            line: i + 1,
+            pattern,
+            message,
+            match: lineMatches[0],
+          });
+        }
+      }
+    }
+  }
+
+  return violations;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export { runAgentReview, buildReviewPrompt, parseReviewJson } from './agent-revi
 export { injectContext, suggestRuleImprovements } from './feedback.js';
 export { detectToolchain, scaffoldRubric, runFirstVerification } from './scaffold.js';
 export { parseSkillFrontmatter, validateSkillFrontmatter, discoverSkills, lintSkills } from './skill-lint.js';
+export { runGuardrailLayer } from './guardrail.js';
 export type {
   CanductorConfig,
   LayerConfig,
@@ -26,4 +27,6 @@ export type {
   SkillFrontmatter,
   SkillLintResult,
   StallDetection,
+  GuardrailPattern,
+  GuardrailViolation,
 } from './types.js';

--- a/packages/core/src/layers.ts
+++ b/packages/core/src/layers.ts
@@ -7,6 +7,7 @@ import { existsSync } from 'node:fs';
 import type { LayerConfig, LayerResult, AgentReviewResult, SelfReviewPrompt } from './types.js';
 import { runAgentReview, buildReviewPrompt } from './agent-review.js';
 import { compareScreenshots } from './screenshot.js';
+import { runGuardrailLayer } from './guardrail.js';
 
 /** Run a deterministic layer (shell command, pass/fail). */
 export function runDeterministicLayer(layer: LayerConfig): LayerResult {
@@ -194,6 +195,8 @@ export async function runLayer(
       return runScreenshotDiffLayer(layer);
     case 'agent-review':
       return runAgentReviewLayer(layer, selfReviewResult);
+    case 'guardrail':
+      return runGuardrailLayer(layer, process.cwd());
     default:
       return {
         name: layer.name,

--- a/packages/core/src/policy.ts
+++ b/packages/core/src/policy.ts
@@ -344,12 +344,14 @@ export function buildPolicyContext(
   compositeScore: number,
   baseline: number
 ): PolicyContext {
+  const deterministicTypes: string[] = ['deterministic', 'guardrail'];
+
   const allDeterministicPass = results
-    .filter(r => r.type === 'deterministic')
+    .filter(r => deterministicTypes.includes(r.type))
     .every(r => r.pass);
 
   const anyDeterministicFail = results
-    .some(r => r.type === 'deterministic' && !r.pass);
+    .some(r => deterministicTypes.includes(r.type) && !r.pass);
 
   const allPass = results.every(r => r.pass);
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -9,7 +9,7 @@
 /** A single verification layer definition. */
 export interface LayerConfig {
   name: string;
-  type: 'deterministic' | 'screenshot-diff' | 'agent-review';
+  type: 'deterministic' | 'screenshot-diff' | 'agent-review' | 'guardrail';
   /** Shell command to run (deterministic layers). */
   run?: string;
   /** Command to capture screenshots (screenshot-diff layers). */
@@ -24,8 +24,29 @@ export interface LayerConfig {
   rubric?: string;
   /** Paths to include as context for agent-review. */
   context?: string[];
+  /** File globs to scan (guardrail layers). */
+  include?: string[];
+  /** File globs to exclude (guardrail layers). */
+  exclude?: string[];
+  /** Forbidden patterns to match (guardrail layers). */
+  patterns?: GuardrailPattern[];
   /** Weight for composite scoring (0-1). */
   weight: number;
+}
+
+/** A pattern to match in guardrail scanning. */
+export interface GuardrailPattern {
+  pattern: string;
+  message: string;
+}
+
+/** A single guardrail violation found in a file. */
+export interface GuardrailViolation {
+  file: string;
+  line: number;
+  pattern: string;
+  message: string;
+  match: string;
 }
 
 /** Policy for auto-merge / human-review / block decisions. */


### PR DESCRIPTION
Closes #40 — implemented autonomously by canductor pipeline.

## Changes
- New `packages/core/src/guardrail.ts` with `runGuardrailLayer()` — scans files for forbidden regex patterns
- Extended `LayerConfig` with `include`, `exclude`, `patterns` fields and added `GuardrailPattern`, `GuardrailViolation` types
- `layers.ts` dispatches to guardrail executor when `type === 'guardrail'`
- `policy.ts` treats guardrail failures as deterministic (`any_deterministic_fail` includes guardrails)
- 10 new tests covering: no violations, violations found, line numbers, exclude globs, multiple patterns, empty config, score calculation

## Verification
- Canductor score: 99/100 (auto_merge)
- All 242 tests pass
- TypeScript strict mode clean