### PR TITLE
Story: Update pipeline skill to call result-update after merge/reject

### DIFF
--- a/.canductor/results.tsv
+++ b/.canductor/results.tsv
@@ -12,3 +12,4 @@ pipeline-migration	2026-03-23T18:17:24.970Z	77	auto_merge	typecheck:100,tests:10
 38	2026-03-23T22:33:21.722Z	99	auto_merge	typecheck:100,tests:100,code_quality:95	pending	Verified 38
 39	2026-03-23T22:37:34.687Z	99	auto_merge	typecheck:100,tests:100,code_quality:94	pending	Verified 39
 40	2026-03-23T22:41:05.895Z	99	auto_merge	typecheck:100,tests:100,code_quality:94	pending	Verified 40
+30	2026-03-23T22:44:10.169Z	99	auto_merge	typecheck:100,tests:100,code_quality:96	pending	Verified 30

--- a/.claude/skills/pipeline/SKILL.md
+++ b/.claude/skills/pipeline/SKILL.md
@@ -187,13 +187,22 @@ If after 6 attempts the decision is still not `auto_merge`:
      --title "WIP: $TITLE" \
      --body "Failed canductor verification after 6 attempts. Needs human review. Ref: #$NUMBER"
    ```
-2. Reset the issue so a future run can retry:
+2. Update the result status to rejected:
+   ```bash
+   node packages/cli/dist/cli.js result-update $NUMBER rejected
+   ```
+3. Reset the issue so a future run can retry:
    ```bash
    gh issue edit $NUMBER --repo johnnyohwishingtree/canductor --remove-label "in-progress" --add-label "pending"
    gh issue comment $NUMBER --repo johnnyohwishingtree/canductor \
      --body "Pipeline failed to meet quality threshold after 6 attempts. WIP PR created for visibility. Resetting to pending."
    ```
-3. **Stop.** Do not proceed to Step 6 or Step 7.
+4. Commit the updated results log:
+   ```bash
+   git add .canductor/results.tsv
+   git diff --cached --quiet || git commit -m "chore: log rejected result for #$NUMBER" && git push -u origin canductor/issue-$NUMBER
+   ```
+5. **Stop.** Do not proceed to Step 6 or Step 7.
 
 ### Step 6: Push, PR, merge, close (only if Step 5 passed)
 
@@ -224,9 +233,10 @@ gh issue edit $NUMBER --repo johnnyohwishingtree/canductor --remove-label "in-pr
 gh issue close $NUMBER --repo johnnyohwishingtree/canductor
 ```
 
-Commit the results log:
+Update the result status to merged and commit the results log:
 ```bash
 git checkout master && git pull origin master
+node packages/cli/dist/cli.js result-update $NUMBER merged
 git add .canductor/results.tsv
 git diff --cached --quiet || git commit -m "chore: log canductor result for #$NUMBER" && git push origin master
 ```


### PR DESCRIPTION
Closes #30 — implemented autonomously by canductor pipeline.

## Changes
- Step 5b: Added `result-update $NUMBER rejected` call and results log commit when verification fails after 6 attempts
- Step 6: Added `result-update $NUMBER merged` call before committing the results log after successful merge
- Closes the feedback loop so results.tsv reflects actual merge/reject outcomes

## Verification
- Canductor score: 99/100 (auto_merge)
- All 242 tests pass
- TypeScript strict mode clean