### PR TITLE
fix: add permissions for scheduled task autonomy

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,41 @@
 {
+  "permissions": {
+    "allow": [
+      "Read(**)",
+      "Edit(**)",
+      "MultiEdit(**)",
+      "Write(**)",
+      "Glob(**)",
+      "Grep(**)",
+      "LS(**)",
+      "Bash(pnpm:*)",
+      "Bash(npm:*)",
+      "Bash(npx:*)",
+      "Bash(node:*)",
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(mkdir:*)",
+      "Bash(cat:*)",
+      "Bash(echo:*)",
+      "Bash(grep:*)",
+      "Bash(ls:*)",
+      "Bash(pwd)",
+      "Bash(cd:*)",
+      "Bash(sleep:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(wc:*)",
+      "Bash(sort:*)",
+      "Bash(sed:*)",
+      "Bash(awk:*)",
+      "Bash(chmod:*)"
+    ],
+    "deny": [
+      "Bash(rm:-rf:/)",
+      "Bash(shutdown:*)",
+      "Bash(reboot:*)"
+    ]
+  },
   "hooks": {
     "PostToolUse": [
       {


### PR DESCRIPTION
## Summary

Claude Code scheduled tasks run with the project's `.claude/settings.json` permissions. Without explicit allows, the task hangs on permission prompts when editing `.claude/` files — blocking the autonomous pipeline.

Adds file operations (Read/Edit/Write) and common Bash commands (pnpm, git, gh, node) to the allow list.

## What was happening

The pipeline scheduled task hit "Edit wants to edit" permission dialogs when modifying `.claude/skills/pipeline/SKILL.md` (Step 4b self-update). Required manual approval from phone.

## What this fixes

Project-level permissions now cover all operations the pipeline needs. Destructive commands (rm -rf /, shutdown) remain denied.