### PR TITLE
feat: add learnings log for persistent failure memory across sessions

### DIFF
--- a/.claude/index.md
+++ b/.claude/index.md
@@ -55,6 +55,7 @@ Stories list which patterns and templates to follow. Patterns reference template
 | File | Purpose |
 |------|---------|
 | `.canductor/config.yaml` | Verification layer definitions + policy |
-| `.canductor/results.tsv` | Verification history log |
+| `.canductor/results.tsv` | Verification history log (scores) |
+| `.canductor/learnings.md` | What went wrong during verify and how it was fixed (narrative) |
 
-<!-- pipeline:index-version:1 -->
+<!-- pipeline:index-version:2 -->

--- a/.claude/skills/pipeline/SKILL.md
+++ b/.claude/skills/pipeline/SKILL.md
@@ -168,7 +168,27 @@ This runs all layers (typecheck, tests, code_quality) with your self-review scor
 
 Read the decision:
 - **`auto_merge`**: proceed to Step 6.
-- **`block`** or **`human_review`**: read the error summary, fix the issues, and loop back to the top of Step 5. This counts as your next attempt.
+- **`block`** or **`human_review`**: **log what failed**, fix the issues, and loop back to the top of Step 5. This counts as your next attempt.
+
+**When verification fails, log the failure before fixing:**
+```bash
+# Append what went wrong to the learnings log
+# This persists across sessions — future pipeline runs read this to avoid repeating mistakes
+cat >> .canductor/learnings.md << LEARNING
+
+### #$NUMBER, attempt $ATTEMPT ($(date -u +"%Y-%m-%dT%H:%M:%SZ"))
+**Failed:** <one-line summary of what the verification output said was wrong>
+LEARNING
+```
+
+After fixing and re-verifying successfully, record how you fixed it:
+```bash
+cat >> .canductor/learnings.md << FIX
+**Fix:** <one-line summary of what you changed to fix it>
+FIX
+```
+
+Commit the learnings file along with your code changes. The next `canductor inject CLAUDE.md` will read these learnings and surface the patterns so future sessions avoid the same mistakes.
 
 **You have up to 6 attempts.** Each attempt: fix -> typecheck -> test -> self-review -> canductor verify with --review-json. Use the error output from each failed verify to guide your fixes.
 

--- a/packages/core/__tests__/learnings.test.ts
+++ b/packages/core/__tests__/learnings.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { appendLearning, recordFix, readLearnings, summarizeLearnings } from '../src/learnings.js';
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'canductor-learnings-'));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('appendLearning', () => {
+  it('creates learnings.md with header on first entry', () => {
+    appendLearning(tempDir, '42', 1, 'typecheck error: unused import on line 5');
+
+    const content = readFileSync(join(tempDir, '.canductor/learnings.md'), 'utf-8');
+    expect(content).toContain('# Canductor Learnings');
+    expect(content).toContain('### #42, attempt 1');
+    expect(content).toContain('**Failed:** typecheck error: unused import on line 5');
+  });
+
+  it('appends to existing file', () => {
+    appendLearning(tempDir, '42', 1, 'tests failed');
+    appendLearning(tempDir, '42', 2, 'coverage dropped');
+
+    const content = readFileSync(join(tempDir, '.canductor/learnings.md'), 'utf-8');
+    expect(content).toContain('### #42, attempt 1');
+    expect(content).toContain('### #42, attempt 2');
+  });
+});
+
+describe('recordFix', () => {
+  it('appends fix to the matching failure entry', () => {
+    appendLearning(tempDir, '42', 1, 'no tests for export.ts');
+    recordFix(tempDir, '42', 1, 'added export.test.ts with 6 tests');
+
+    const content = readFileSync(join(tempDir, '.canductor/learnings.md'), 'utf-8');
+    expect(content).toContain('**Failed:** no tests for export.ts');
+    expect(content).toContain('**Fix:** added export.test.ts with 6 tests');
+  });
+
+  it('does nothing if learnings file does not exist', () => {
+    recordFix(tempDir, '42', 1, 'some fix');
+    // Should not throw or create the file
+    expect(() => readFileSync(join(tempDir, '.canductor/learnings.md'))).toThrow();
+  });
+});
+
+describe('readLearnings', () => {
+  it('returns empty array when no file exists', () => {
+    expect(readLearnings(tempDir)).toHaveLength(0);
+  });
+
+  it('parses learnings with failures and fixes', () => {
+    appendLearning(tempDir, '42', 1, 'tests failed');
+    recordFix(tempDir, '42', 1, 'fixed the assertion');
+    appendLearning(tempDir, '43', 1, 'coverage dropped 5%');
+
+    const learnings = readLearnings(tempDir);
+    expect(learnings).toHaveLength(2);
+
+    expect(learnings[0].ref).toBe('42');
+    expect(learnings[0].attempt).toBe(1);
+    expect(learnings[0].failure).toBe('tests failed');
+    expect(learnings[0].fix).toBe('fixed the assertion');
+
+    expect(learnings[1].ref).toBe('43');
+    expect(learnings[1].failure).toBe('coverage dropped 5%');
+    expect(learnings[1].fix).toBe('');
+  });
+});
+
+describe('summarizeLearnings', () => {
+  it('returns empty string when no learnings', () => {
+    expect(summarizeLearnings(tempDir)).toBe('');
+  });
+
+  it('groups failures by category', () => {
+    appendLearning(tempDir, '42', 1, 'no tests for new module export.ts');
+    recordFix(tempDir, '42', 1, 'added export.test.ts');
+    appendLearning(tempDir, '43', 1, 'test coverage dropped from 87% to 83%');
+    recordFix(tempDir, '43', 1, 'added missing tests for all new functions');
+    appendLearning(tempDir, '44', 1, 'typecheck error TS2304 on line 15');
+
+    const summary = summarizeLearnings(tempDir);
+    expect(summary).toContain('Learnings from past failures');
+    expect(summary).toContain('missing tests');
+    expect(summary).toContain('type errors');
+  });
+
+  it('includes fix suggestions from past fixes', () => {
+    appendLearning(tempDir, '42', 1, 'new file had no tests, coverage dropped');
+    recordFix(tempDir, '42', 1, 'always add a test file when creating a new module');
+
+    const summary = summarizeLearnings(tempDir);
+    expect(summary).toContain('Fix:');
+    expect(summary).toContain('always add a test file');
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,8 @@ export { evaluateExpression, evaluateAllPolicies, buildPolicyContext } from './p
 export type { PolicyContext } from './policy.js';
 export { runAgentReview, buildReviewPrompt, parseReviewJson } from './agent-review.js';
 export { injectContext, suggestRuleImprovements } from './feedback.js';
+export { appendLearning, recordFix, readLearnings, summarizeLearnings } from './learnings.js';
+export type { Learning } from './learnings.js';
 export { detectToolchain, scaffoldRubric, runFirstVerification } from './scaffold.js';
 export { parseSkillFrontmatter, validateSkillFrontmatter, discoverSkills, lintSkills } from './skill-lint.js';
 export { runGuardrailLayer } from './guardrail.js';

--- a/packages/core/src/learnings.ts
+++ b/packages/core/src/learnings.ts
@@ -1,0 +1,157 @@
+/**
+ * Learnings log — captures what went wrong during verification attempts
+ * and how it was fixed. This is the persistent memory between sessions.
+ *
+ * Unlike results.tsv (scores), learnings.md captures the narrative:
+ * what failed, why, and what the fix was. This is what makes the
+ * autoresearch-style loop work — agents read past failures and avoid
+ * repeating them.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+
+const LEARNINGS_PATH = '.canductor/learnings.md';
+
+export interface Learning {
+  ref: string;
+  attempt: number;
+  timestamp: string;
+  failure: string;
+  fix: string;
+}
+
+/**
+ * Append a learning entry when a verify attempt fails.
+ * Called by the pipeline skill during the fix loop.
+ */
+export function appendLearning(
+  repoRoot: string,
+  ref: string,
+  attempt: number,
+  failure: string,
+): void {
+  const fullPath = join(repoRoot, LEARNINGS_PATH);
+  const dir = dirname(fullPath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+  const timestamp = new Date().toISOString();
+  const entry = `### #${ref}, attempt ${attempt} (${timestamp})\n**Failed:** ${failure}\n\n`;
+
+  if (!existsSync(fullPath)) {
+    writeFileSync(fullPath, `# Canductor Learnings\n\nWhat went wrong during verification and how it was fixed.\nThis file is read by \`canductor inject\` to prevent repeating mistakes.\n\n${entry}`);
+  } else {
+    const content = readFileSync(fullPath, 'utf-8');
+    writeFileSync(fullPath, content.trimEnd() + '\n\n' + entry);
+  }
+}
+
+/**
+ * Record the fix that resolved a failure.
+ * Called after the agent fixes the issue and verify passes.
+ */
+export function recordFix(
+  repoRoot: string,
+  ref: string,
+  attempt: number,
+  fix: string,
+): void {
+  const fullPath = join(repoRoot, LEARNINGS_PATH);
+  if (!existsSync(fullPath)) return;
+
+  const content = readFileSync(fullPath, 'utf-8');
+  const marker = `### #${ref}, attempt ${attempt}`;
+  const idx = content.lastIndexOf(marker);
+  if (idx === -1) return;
+
+  // Find end of the failure block and append the fix
+  const afterMarker = content.substring(idx);
+  const nextEntry = afterMarker.indexOf('\n### ', 1);
+  const insertPoint = nextEntry !== -1
+    ? idx + nextEntry
+    : content.length;
+
+  const fixBlock = `**Fix:** ${fix}\n`;
+  const updated = content.substring(0, insertPoint).trimEnd() + '\n' + fixBlock + '\n' + content.substring(insertPoint);
+  writeFileSync(fullPath, updated);
+}
+
+/**
+ * Read all learnings and return them as structured data.
+ */
+export function readLearnings(repoRoot: string): Learning[] {
+  const fullPath = join(repoRoot, LEARNINGS_PATH);
+  if (!existsSync(fullPath)) return [];
+
+  const content = readFileSync(fullPath, 'utf-8');
+  const entries = content.split(/(?=### #)/);
+  const learnings: Learning[] = [];
+
+  for (const entry of entries) {
+    const headerMatch = entry.match(/^### #(.+?), attempt (\d+) \((.+?)\)/);
+    if (!headerMatch) continue;
+
+    const failureMatch = entry.match(/\*\*Failed:\*\* (.+?)(?:\n|$)/);
+    const fixMatch = entry.match(/\*\*Fix:\*\* (.+?)(?:\n|$)/);
+
+    learnings.push({
+      ref: headerMatch[1],
+      attempt: parseInt(headerMatch[2]),
+      timestamp: headerMatch[3],
+      failure: failureMatch?.[1] ?? '',
+      fix: fixMatch?.[1] ?? '',
+    });
+  }
+
+  return learnings;
+}
+
+/**
+ * Summarize learnings into actionable patterns for prompt injection.
+ * Groups similar failures and extracts the lessons.
+ */
+export function summarizeLearnings(repoRoot: string): string {
+  const learnings = readLearnings(repoRoot);
+  if (learnings.length === 0) return '';
+
+  // Group failures by pattern (simple keyword matching)
+  const patterns = new Map<string, { count: number; examples: string[]; fixes: string[] }>();
+
+  const categorize = (failure: string): string => {
+    const lower = failure.toLowerCase();
+    if (lower.includes('coverage') || lower.includes('no tests') || lower.includes('test coverage')) return 'missing-tests';
+    if (lower.includes('typecheck') || lower.includes('error ts') || lower.includes('type error')) return 'type-errors';
+    if (lower.includes('unused') || lower.includes('import')) return 'unused-code';
+    if (lower.includes('export') || lower.includes('index.ts') || lower.includes('barrel')) return 'missing-exports';
+    if (lower.includes('lint') || lower.includes('eslint')) return 'lint-errors';
+    if (lower.includes('build') || lower.includes('bundle') || lower.includes('compile')) return 'build-errors';
+    return 'other';
+  };
+
+  for (const l of learnings) {
+    if (!l.failure) continue;
+    const category = categorize(l.failure);
+    const existing = patterns.get(category) ?? { count: 0, examples: [], fixes: [] };
+    existing.count++;
+    if (existing.examples.length < 2) existing.examples.push(`#${l.ref}: ${l.failure}`);
+    if (l.fix && existing.fixes.length < 2) existing.fixes.push(l.fix);
+    patterns.set(category, existing);
+  }
+
+  const lines: string[] = ['### Learnings from past failures:'];
+
+  // Sort by count descending — most common failures first
+  const sorted = [...patterns.entries()].sort((a, b) => b[1].count - a[1].count);
+
+  for (const [category, data] of sorted) {
+    if (data.count < 1) continue;
+
+    const label = category.replace('-', ' ');
+    lines.push(`- **${label}** (${data.count}x): ${data.examples[0]}`);
+    if (data.fixes.length > 0) {
+      lines.push(`  - Fix: ${data.fixes[0]}`);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/packages/core/src/results.ts
+++ b/packages/core/src/results.ts
@@ -8,6 +8,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import type { ResultRow, VerifyResult, QualityContext, CanductorConfig, StallDetection } from './types.js';
+import { summarizeLearnings } from './learnings.js';
 
 const RESULTS_PATH = '.canductor/results.tsv';
 const HEADER = 'ref\ttimestamp\tcomposite_score\tdecision\tlayer_scores\tstatus\tdescription';
@@ -521,6 +522,13 @@ export function generatePromptContext(repoRoot: string): string {
     for (const stall of ctx.stalls) {
       lines.push(`- ${stall.suggestion}`);
     }
+    lines.push('');
+  }
+
+  // Include learnings from past failures
+  const learningsSummary = summarizeLearnings(repoRoot);
+  if (learningsSummary) {
+    lines.push(learningsSummary);
     lines.push('');
   }
 


### PR DESCRIPTION
## The Problem

Canductor's self-review scores are always 98-99 because Claude grades itself. There's no real failure signal — and without failures, nothing improves.

## The Fix

When verification actually fails during the pipeline's fix loop (Step 5), the failure and its fix are now written to `.canductor/learnings.md`. This file persists across sessions and gets surfaced by `canductor inject CLAUDE.md`.

### How it works

```
Session 1 (story #60):
  attempt 1: verify fails → writes "Failed: no tests for export.ts"
  attempt 2: adds tests → writes "Fix: added export.test.ts"
  → merges

Session 2 (story #61):
  canductor inject → reads learnings.md
  → injects: "Learnings: missing tests (1x). Fix: always add test file for new modules."
  → agent writes tests from the start
  → passes on attempt 1
```

### Changes

- **`packages/core/src/learnings.ts`** — new module: appendLearning, recordFix, readLearnings, summarizeLearnings
- **`packages/core/src/results.ts`** — generatePromptContext now includes learnings summary
- **`.claude/skills/pipeline/SKILL.md`** — Step 5 writes to learnings.md on failure
- 9 new tests, 246 total passing

Closes #(N/A — infrastructure improvement)