### PR TITLE
Add canductor config-check command to validate config

### DIFF
--- a/.canductor/results.tsv
+++ b/.canductor/results.tsv
@@ -24,3 +24,4 @@ guard-ref	2026-03-23T23:13:27.937Z	38	block	typecheck:100,tests:0,code_quality:0
 64	2026-03-24T02:25:17.774Z	98	auto_merge	typecheck:100,tests:100,code_quality:92	merged	Verified 64
 65	2026-03-24T02:30:56.245Z	98	auto_merge	typecheck:100,tests:100,code_quality:92	merged	Verified 65
 69	2026-03-24T02:34:20.423Z	98	auto_merge	typecheck:100,tests:100,code_quality:91	merged	Verified 69
+74	2026-03-24T02:49:39.584Z	99	auto_merge	typecheck:100,tests:100,code_quality:94	pending	Verified 74

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -38,6 +38,7 @@ import {
   generateReport,
   listStaleBranches,
   deleteBranches,
+  validateConfig,
 } from '@canductor/core';
 import type { AgentReviewResult } from '@canductor/core';
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
@@ -69,6 +70,7 @@ Usage:
   canductor suggest                          Suggest rule improvements based on history
   canductor init                             Create starter config
   canductor report [ref] [--json]             Generate markdown quality summary
+  canductor config-check [--json]             Validate config file and policy expressions
   canductor clean [--force]                  Remove merged canductor branches
   canductor skill-lint                       Validate SKILL.md frontmatter
   canductor help                             Show this message
@@ -607,6 +609,37 @@ function cmdSkillLint(): void {
   }
 }
 
+function cmdConfigCheck(): void {
+  const jsonMode = args.includes('--json');
+  const result = validateConfig(repoRoot);
+
+  if (jsonMode) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    if (result.errors.length === 0 && result.warnings.length === 0) {
+      console.log('Config is valid. No errors or warnings.');
+    } else {
+      for (const issue of result.errors) {
+        const pathStr = issue.path ? ` (${issue.path})` : '';
+        console.log(`ERROR${pathStr}: ${issue.message}`);
+      }
+      for (const issue of result.warnings) {
+        const pathStr = issue.path ? ` (${issue.path})` : '';
+        console.log(`WARNING${pathStr}: ${issue.message}`);
+      }
+
+      const summary = [];
+      if (result.errors.length > 0) summary.push(`${result.errors.length} error(s)`);
+      if (result.warnings.length > 0) summary.push(`${result.warnings.length} warning(s)`);
+      console.log(`\n${summary.join(', ')}`);
+    }
+  }
+
+  if (!result.valid) {
+    process.exit(1);
+  }
+}
+
 async function main(): Promise<void> {
   switch (command) {
     case 'verify':
@@ -647,6 +680,9 @@ async function main(): Promise<void> {
       break;
     case 'report':
       cmdReport();
+      break;
+    case 'config-check':
+      cmdConfigCheck();
       break;
     case 'clean':
       cmdClean();

--- a/packages/core/__tests__/config.test.ts
+++ b/packages/core/__tests__/config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { loadConfig, writeConfigBaseline } from '../src/config.js';
+import { loadConfig, writeConfigBaseline, validateConfig } from '../src/config.js';
 
 let tempDir: string;
 
@@ -312,5 +312,158 @@ policy:
     const config = loadConfig(tempDir);
     expect(config.layers.tests.type).toBe('deterministic');
     expect(config.layers.guard.type).toBe('guardrail');
+  });
+});
+
+describe('validateConfig', () => {
+  it('returns valid for a correct config', () => {
+    writeConfig(minimalConfig);
+    const result = validateConfig(tempDir);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('returns error when no config file exists', () => {
+    const result = validateConfig(tempDir);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0].message).toContain('No config file found');
+  });
+
+  it('returns error when YAML is invalid', () => {
+    const dir = join(tempDir, '.canductor');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.yaml'), ': : : bad yaml [[[');
+    const result = validateConfig(tempDir);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes('parse'))).toBe(true);
+  });
+
+  it('returns error for invalid schema (missing version)', () => {
+    writeConfig(`layers:
+  tests:
+    name: tests
+    type: deterministic
+    run: "npm test"
+    weight: 1.0
+policy:
+  auto_merge: "all_pass"
+  human_review: "false"
+  block: "any_fail"
+`);
+    const result = validateConfig(tempDir);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('returns error for missing rubric file on agent-review layer', () => {
+    writeConfig(`version: 1
+layers:
+  review:
+    name: review
+    type: agent-review
+    rubric: "nonexistent-rubric.md"
+    weight: 0.5
+policy:
+  auto_merge: "all_pass"
+  human_review: "false"
+  block: "any_fail"
+`);
+    const result = validateConfig(tempDir);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes('Rubric file not found'))).toBe(true);
+    expect(result.errors.some(e => e.path === 'layers.review.rubric')).toBe(true);
+  });
+
+  it('returns error for invalid policy expression syntax', () => {
+    writeConfig(`version: 1
+layers:
+  tests:
+    name: tests
+    type: deterministic
+    run: "npm test"
+    weight: 1.0
+policy:
+  auto_merge: "all_pass AND AND"
+  human_review: "false"
+  block: "any_fail"
+`);
+    const result = validateConfig(tempDir);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes('Invalid policy expression'))).toBe(true);
+  });
+
+  it('returns error for guardrail layer with no include and no patterns', () => {
+    writeConfig(`version: 1
+layers:
+  guard:
+    name: guard
+    type: guardrail
+    weight: 0.2
+policy:
+  auto_merge: "all_pass"
+  human_review: "false"
+  block: "any_fail"
+`);
+    const result = validateConfig(tempDir);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes('nothing to check'))).toBe(true);
+  });
+
+  it('warns when all weights sum to zero', () => {
+    writeConfig(`version: 1
+layers:
+  tests:
+    name: tests
+    type: deterministic
+    run: "npm test"
+    weight: 0
+policy:
+  auto_merge: "all_pass"
+  human_review: "false"
+  block: "any_fail"
+`);
+    const result = validateConfig(tempDir);
+    expect(result.valid).toBe(true);
+    expect(result.warnings.some(w => w.message.includes('weights sum to 0'))).toBe(true);
+  });
+
+  it('returns error for deterministic layer without run command', () => {
+    writeConfig(`version: 1
+layers:
+  tests:
+    name: tests
+    type: deterministic
+    weight: 1.0
+policy:
+  auto_merge: "all_pass"
+  human_review: "false"
+  block: "any_fail"
+`);
+    const result = validateConfig(tempDir);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes('no run command'))).toBe(true);
+  });
+
+  it('passes when rubric file exists', () => {
+    const rubricDir = join(tempDir, 'rubrics');
+    mkdirSync(rubricDir, { recursive: true });
+    writeFileSync(join(rubricDir, 'quality.md'), '# Quality rubric');
+    writeConfig(`version: 1
+layers:
+  review:
+    name: review
+    type: agent-review
+    rubric: "rubrics/quality.md"
+    weight: 0.5
+policy:
+  auto_merge: "all_pass"
+  human_review: "false"
+  block: "any_fail"
+`);
+    const result = validateConfig(tempDir);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
   });
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -6,7 +6,8 @@ import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { z } from 'zod';
-import type { CanductorConfig } from './types.js';
+import type { CanductorConfig, ConfigValidation, ConfigValidationIssue } from './types.js';
+import { evaluateExpression, buildPolicyContext } from './policy.js';
 
 const GuardrailPatternSchema = z.object({
   pattern: z.string(),
@@ -86,4 +87,155 @@ export function writeConfigBaseline(repoRoot: string, baseline: number): void {
   const parsed = parseYaml(raw);
   parsed.baseline = baseline;
   writeFileSync(configPath, stringifyYaml(parsed));
+}
+
+/**
+ * Validate a canductor config without running any layers.
+ * Checks: file exists, YAML parses, Zod schema validates, policy expressions parse,
+ * rubric files exist for agent-review layers, run commands non-empty for deterministic,
+ * include/patterns non-empty for guardrail layers.
+ */
+export function validateConfig(repoRoot: string): ConfigValidation {
+  const errors: ConfigValidationIssue[] = [];
+  const warnings: ConfigValidationIssue[] = [];
+
+  // Check config file exists
+  const configPath = findConfigPath(repoRoot);
+  if (!configPath) {
+    errors.push({
+      level: 'error',
+      message: `No config file found. Expected one of: ${CONFIG_PATHS.join(', ')}`,
+    });
+    return { valid: false, errors, warnings };
+  }
+
+  // Check YAML parses
+  let raw: string;
+  let parsed: unknown;
+  try {
+    raw = readFileSync(configPath, 'utf-8');
+    parsed = parseYaml(raw);
+  } catch (err) {
+    errors.push({
+      level: 'error',
+      message: `Failed to parse YAML: ${(err as Error).message}`,
+      path: configPath,
+    });
+    return { valid: false, errors, warnings };
+  }
+
+  // Check Zod schema validates
+  const result = ConfigSchema.safeParse(parsed);
+  if (!result.success) {
+    for (const issue of result.error.issues) {
+      const path = issue.path.length > 0 ? issue.path.join('.') : undefined;
+      errors.push({
+        level: 'error',
+        message: issue.message,
+        path,
+      });
+    }
+    return { valid: false, errors, warnings };
+  }
+
+  const config = result.data as CanductorConfig;
+
+  // Check layer-specific requirements
+  const layerEntries = Object.entries(config.layers);
+  let totalWeight = 0;
+
+  for (const [key, layer] of layerEntries) {
+    totalWeight += layer.weight;
+
+    if (layer.type === 'deterministic' && (!layer.run || layer.run.trim() === '')) {
+      errors.push({
+        level: 'error',
+        message: `Deterministic layer "${key}" has no run command`,
+        path: `layers.${key}.run`,
+      });
+    }
+
+    if (layer.type === 'agent-review' && layer.rubric) {
+      const rubricPath = join(repoRoot, layer.rubric);
+      if (!existsSync(rubricPath)) {
+        errors.push({
+          level: 'error',
+          message: `Rubric file not found: ${layer.rubric}`,
+          path: `layers.${key}.rubric`,
+        });
+      }
+    }
+
+    if (layer.type === 'guardrail') {
+      if ((!layer.include || layer.include.length === 0) && (!layer.patterns || layer.patterns.length === 0)) {
+        errors.push({
+          level: 'error',
+          message: `Guardrail layer "${key}" has no include patterns and no patterns — nothing to check`,
+          path: `layers.${key}`,
+        });
+      }
+    }
+  }
+
+  // Warn on suspicious weight sums
+  if (totalWeight === 0 && layerEntries.length > 0) {
+    warnings.push({
+      level: 'warning',
+      message: 'All layer weights sum to 0 — no scoring is possible',
+    });
+  }
+
+  // Warn on suspicious baseline
+  if (config.baseline !== undefined) {
+    if (config.baseline > 100) {
+      warnings.push({
+        level: 'warning',
+        message: `Baseline ${config.baseline} is greater than 100`,
+        path: 'baseline',
+      });
+    }
+    if (config.baseline < 0) {
+      warnings.push({
+        level: 'warning',
+        message: `Baseline ${config.baseline} is less than 0`,
+        path: 'baseline',
+      });
+    }
+  }
+
+  // Check policy expressions parse by evaluating with a dummy context
+  // populated from the config's layers so all layer identifiers resolve.
+  const dummyLayerResults: import('./types.js').LayerResult[] = Object.entries(config.layers).map(
+    ([key, layer]) => ({
+      name: key,
+      type: layer.type,
+      pass: true,
+      score: 100,
+      errors: '',
+      duration_ms: 0,
+    })
+  );
+  const dummyContext = buildPolicyContext(dummyLayerResults, 100, 100);
+  for (const [policyName, expr] of Object.entries(config.policy)) {
+    try {
+      evaluateExpression(expr, dummyContext);
+    } catch (err) {
+      const msg = (err as Error).message;
+      // Skip unknown identifier errors — they may reference runtime-only values.
+      // Only report actual syntax/parse errors.
+      if (!msg.includes('Unknown identifier') && !msg.includes('Unknown layer') && !msg.includes('Unknown field')) {
+        errors.push({
+          level: 'error',
+          message: `Invalid policy expression for "${policyName}": ${msg}`,
+          path: `policy.${policyName}`,
+        });
+      }
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export { loadConfig, findConfigPath, writeConfigBaseline } from './config.js';
+export { loadConfig, findConfigPath, writeConfigBaseline, validateConfig } from './config.js';
 export { verify, computeCompositeScore, evaluatePolicy } from './verify.js';
 export { runLayer, runDeterministicLayer, runScreenshotDiffLayer, runAgentReviewLayer, getAgentReviewPrompt } from './layers.js';
 export { readResults, appendResult, updateResultStatus, analyzeResults, detectStalls, generatePromptContext, diffResults, getStatus, getTrend, computeAutoBaseline, getBaseline } from './results.js';
@@ -35,4 +35,6 @@ export type {
   StallDetection,
   GuardrailPattern,
   GuardrailViolation,
+  ConfigValidation,
+  ConfigValidationIssue,
 } from './types.js';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -159,6 +159,20 @@ export interface StallDetection {
   suggestion: string;
 }
 
+/** A single issue found during config validation. */
+export interface ConfigValidationIssue {
+  level: 'error' | 'warning';
+  message: string;
+  path?: string;
+}
+
+/** Result of validating a canductor config file. */
+export interface ConfigValidation {
+  valid: boolean;
+  errors: ConfigValidationIssue[];
+  warnings: ConfigValidationIssue[];
+}
+
 /** Context injected into agent prompts based on results history. */
 export interface QualityContext {
   /** Recent results summary. */


### PR DESCRIPTION
Closes #74 — implemented autonomously by canductor pipeline.

Adds `validateConfig()` to core and `canductor config-check` CLI command that validates config without running any layers. Checks:
- Config file exists and YAML parses
- Zod schema validates
- Policy expressions parse correctly
- Rubric files exist for agent-review layers
- Run commands present for deterministic layers
- Include/patterns present for guardrail layers
- Warns on zero weight sums

Supports `--json` output. 10 new tests covering all validation paths.

Canductor score: 99/100 (auto_merge)

Session: https://claude.ai/code