### PR TITLE
Add canductor layers command to list configured layers

### DIFF
--- a/.canductor/results.tsv
+++ b/.canductor/results.tsv
@@ -25,3 +25,4 @@ guard-ref	2026-03-23T23:13:27.937Z	38	block	typecheck:100,tests:0,code_quality:0
 65	2026-03-24T02:30:56.245Z	98	auto_merge	typecheck:100,tests:100,code_quality:92	merged	Verified 65
 69	2026-03-24T02:34:20.423Z	98	auto_merge	typecheck:100,tests:100,code_quality:91	merged	Verified 69
 74	2026-03-24T02:49:39.584Z	99	auto_merge	typecheck:100,tests:100,code_quality:94	merged	Verified 74
+75	2026-03-24T02:53:21.002Z	98	auto_merge	typecheck:100,tests:100,code_quality:93	pending	Verified 75

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -39,6 +39,7 @@ import {
   listStaleBranches,
   deleteBranches,
   validateConfig,
+  listLayers,
 } from '@canductor/core';
 import type { AgentReviewResult } from '@canductor/core';
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
@@ -70,6 +71,7 @@ Usage:
   canductor suggest                          Suggest rule improvements based on history
   canductor init                             Create starter config
   canductor report [ref] [--json]             Generate markdown quality summary
+  canductor layers [--json]                   List configured verification layers
   canductor config-check [--json]             Validate config file and policy expressions
   canductor clean [--force]                  Remove merged canductor branches
   canductor skill-lint                       Validate SKILL.md frontmatter
@@ -609,6 +611,38 @@ function cmdSkillLint(): void {
   }
 }
 
+function cmdLayers(): void {
+  const jsonMode = args.includes('--json');
+  const config = loadConfig(repoRoot);
+  const layers = listLayers(config);
+
+  if (layers.length === 0) {
+    if (jsonMode) {
+      console.log(JSON.stringify([]));
+    } else {
+      console.log('No layers configured.');
+    }
+    return;
+  }
+
+  if (jsonMode) {
+    console.log(JSON.stringify(layers, null, 2));
+    return;
+  }
+
+  console.log('Name'.padEnd(20) + 'Type'.padEnd(20) + 'Weight'.padEnd(10) + 'Detail');
+  console.log('-'.repeat(70));
+  for (const layer of layers) {
+    console.log(
+      `${layer.name.padEnd(20)}${layer.type.padEnd(20)}${String(layer.weight).padEnd(10)}${layer.detail}`
+    );
+  }
+
+  const totalWeight = layers.reduce((sum, l) => sum + l.weight, 0);
+  console.log('-'.repeat(70));
+  console.log(`${''.padEnd(40)}${totalWeight.toFixed(1)}`);
+}
+
 function cmdConfigCheck(): void {
   const jsonMode = args.includes('--json');
   const result = validateConfig(repoRoot);
@@ -680,6 +714,9 @@ async function main(): Promise<void> {
       break;
     case 'report':
       cmdReport();
+      break;
+    case 'layers':
+      cmdLayers();
       break;
     case 'config-check':
       cmdConfigCheck();

--- a/packages/core/__tests__/config.test.ts
+++ b/packages/core/__tests__/config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { loadConfig, writeConfigBaseline, validateConfig } from '../src/config.js';
+import { loadConfig, writeConfigBaseline, validateConfig, listLayers } from '../src/config.js';
 
 let tempDir: string;
 
@@ -465,5 +465,88 @@ policy:
     const result = validateConfig(tempDir);
     expect(result.valid).toBe(true);
     expect(result.errors).toHaveLength(0);
+  });
+});
+
+describe('listLayers', () => {
+  it('lists layers with correct type, weight, and detail', () => {
+    writeConfig(`version: 1
+layers:
+  tests:
+    name: tests
+    type: deterministic
+    run: "npm test"
+    weight: 0.5
+  review:
+    name: review
+    type: agent-review
+    rubric: "quality.md"
+    weight: 0.3
+  guard:
+    name: guard
+    type: guardrail
+    patterns:
+      - pattern: "eval"
+        message: "No eval"
+      - pattern: "debugger"
+        message: "No debugger"
+    weight: 0.2
+policy:
+  auto_merge: "all_pass"
+  human_review: "false"
+  block: "any_fail"
+`);
+    const config = loadConfig(tempDir);
+    const layers = listLayers(config);
+
+    expect(layers).toHaveLength(3);
+
+    expect(layers[0].name).toBe('tests');
+    expect(layers[0].type).toBe('deterministic');
+    expect(layers[0].weight).toBe(0.5);
+    expect(layers[0].detail).toBe('run: npm test');
+
+    expect(layers[1].name).toBe('review');
+    expect(layers[1].type).toBe('agent-review');
+    expect(layers[1].weight).toBe(0.3);
+    expect(layers[1].detail).toBe('rubric: quality.md');
+
+    expect(layers[2].name).toBe('guard');
+    expect(layers[2].type).toBe('guardrail');
+    expect(layers[2].weight).toBe(0.2);
+    expect(layers[2].detail).toBe('2 pattern(s)');
+  });
+
+  it('returns empty array for config with no layers', () => {
+    writeConfig(`version: 1
+layers: {}
+policy:
+  auto_merge: "all_pass"
+  human_review: "false"
+  block: "any_fail"
+`);
+    const config = loadConfig(tempDir);
+    const layers = listLayers(config);
+    expect(layers).toHaveLength(0);
+  });
+
+  it('shows screenshot-diff baseline detail', () => {
+    writeConfig(`version: 1
+layers:
+  visual:
+    name: visual
+    type: screenshot-diff
+    capture: "npm run screenshot"
+    baseline: "screenshots/"
+    threshold: 5
+    weight: 0.8
+policy:
+  auto_merge: "all_pass"
+  human_review: "false"
+  block: "any_fail"
+`);
+    const config = loadConfig(tempDir);
+    const layers = listLayers(config);
+    expect(layers[0].detail).toBe('baseline: screenshots/');
   });
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -6,7 +6,7 @@ import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { z } from 'zod';
-import type { CanductorConfig, ConfigValidation, ConfigValidationIssue } from './types.js';
+import type { CanductorConfig, ConfigValidation, ConfigValidationIssue, LayerInfo } from './types.js';
 import { evaluateExpression, buildPolicyContext } from './policy.js';
 
 const GuardrailPatternSchema = z.object({
@@ -87,6 +87,32 @@ export function writeConfigBaseline(repoRoot: string, baseline: number): void {
   const parsed = parseYaml(raw);
   parsed.baseline = baseline;
   writeFileSync(configPath, stringifyYaml(parsed));
+}
+
+/**
+ * List all configured verification layers with their type, weight, and key detail.
+ */
+export function listLayers(config: CanductorConfig): LayerInfo[] {
+  return Object.entries(config.layers).map(([key, layer]) => {
+    let detail: string;
+    switch (layer.type) {
+      case 'deterministic':
+        detail = layer.run ? `run: ${layer.run}` : 'no run command';
+        break;
+      case 'agent-review':
+        detail = layer.rubric ? `rubric: ${layer.rubric}` : 'no rubric';
+        break;
+      case 'guardrail':
+        detail = layer.patterns ? `${layer.patterns.length} pattern(s)` : 'no patterns';
+        break;
+      case 'screenshot-diff':
+        detail = layer.baseline ? `baseline: ${layer.baseline}` : 'no baseline';
+        break;
+      default:
+        detail = '';
+    }
+    return { name: key, type: layer.type, weight: layer.weight, detail };
+  });
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export { loadConfig, findConfigPath, writeConfigBaseline, validateConfig } from './config.js';
+export { loadConfig, findConfigPath, writeConfigBaseline, validateConfig, listLayers } from './config.js';
 export { verify, computeCompositeScore, evaluatePolicy } from './verify.js';
 export { runLayer, runDeterministicLayer, runScreenshotDiffLayer, runAgentReviewLayer, getAgentReviewPrompt } from './layers.js';
 export { readResults, appendResult, updateResultStatus, analyzeResults, detectStalls, generatePromptContext, diffResults, getStatus, getTrend, computeAutoBaseline, getBaseline } from './results.js';
@@ -37,4 +37,5 @@ export type {
   GuardrailViolation,
   ConfigValidation,
   ConfigValidationIssue,
+  LayerInfo,
 } from './types.js';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -65,6 +65,14 @@ export interface CanductorConfig {
   baseline?: number;
 }
 
+/** Summary info for a configured verification layer. */
+export interface LayerInfo {
+  name: string;
+  type: LayerConfig['type'];
+  weight: number;
+  detail: string;
+}
+
 /** Result of running a single verification layer. */
 export interface LayerResult {
   name: string;


### PR DESCRIPTION
Closes #75 — implemented autonomously by canductor pipeline.

Adds `listLayers()` to core and `canductor layers` CLI command that lists all configured verification layers with their type, weight, and key detail. Supports `--json` output and shows total weight sum. 3 new tests covering mixed layer types, empty config, and screenshot-diff detail.

Canductor score: 98/100 (auto_merge)

Session: https://claude.ai/code