### PR TITLE
Add canductor layer-test command to run a single layer

### DIFF
--- a/.canductor/results.tsv
+++ b/.canductor/results.tsv
@@ -26,3 +26,4 @@ guard-ref	2026-03-23T23:13:27.937Z	38	block	typecheck:100,tests:0,code_quality:0
 69	2026-03-24T02:34:20.423Z	98	auto_merge	typecheck:100,tests:100,code_quality:91	merged	Verified 69
 74	2026-03-24T02:49:39.584Z	99	auto_merge	typecheck:100,tests:100,code_quality:94	merged	Verified 74
 75	2026-03-24T02:53:21.002Z	98	auto_merge	typecheck:100,tests:100,code_quality:93	merged	Verified 75
+76	2026-03-24T02:55:18.367Z	98	auto_merge	typecheck:100,tests:100,code_quality:92	pending	Verified 76

--- a/packages/cli/__tests__/cli.test.ts
+++ b/packages/cli/__tests__/cli.test.ts
@@ -788,6 +788,40 @@ describe('canductor suggest', () => {
   });
 });
 
+describe('canductor layer-test', () => {
+  beforeEach(() => setupConfig(TEST_DIR));
+
+  it('runs a passing layer and shows result', () => {
+    const { stdout, exitCode } = runCli('layer-test echo_test');
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('PASS');
+    expect(stdout).toContain('echo_test');
+    expect(stdout).toContain('Score: 100/100');
+  });
+
+  it('outputs JSON with --json flag', () => {
+    const { stdout, exitCode } = runCli('layer-test echo_test --json');
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout);
+    expect(result.name).toBe('echo_test');
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(100);
+  });
+
+  it('shows error for unknown layer name', () => {
+    const { stdout, exitCode } = runCli('layer-test nonexistent');
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Layer not found: nonexistent');
+    expect(stdout).toContain('Available layers:');
+  });
+
+  it('shows usage when no layer name provided', () => {
+    const { stdout, exitCode } = runCli('layer-test');
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Usage:');
+  });
+});
+
 describe('unknown command', () => {
   it('shows error and usage for unknown commands', () => {
     const { stdout, exitCode } = runCli('nonexistent');

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -40,6 +40,7 @@ import {
   deleteBranches,
   validateConfig,
   listLayers,
+  runLayer,
 } from '@canductor/core';
 import type { AgentReviewResult } from '@canductor/core';
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
@@ -72,6 +73,7 @@ Usage:
   canductor init                             Create starter config
   canductor report [ref] [--json]             Generate markdown quality summary
   canductor layers [--json]                   List configured verification layers
+  canductor layer-test <name> [--json]        Run a single layer in isolation
   canductor config-check [--json]             Validate config file and policy expressions
   canductor clean [--force]                  Remove merged canductor branches
   canductor skill-lint                       Validate SKILL.md frontmatter
@@ -611,6 +613,44 @@ function cmdSkillLint(): void {
   }
 }
 
+async function cmdLayerTest(): Promise<void> {
+  const layerName = args[1];
+  const jsonMode = args.includes('--json');
+
+  if (!layerName || layerName.startsWith('--')) {
+    console.error('Usage: canductor layer-test <layer-name>');
+    process.exit(1);
+  }
+
+  const config = loadConfig(repoRoot);
+  const layerConfig = config.layers[layerName];
+
+  if (!layerConfig) {
+    const available = Object.keys(config.layers).join(', ');
+    console.error(`Layer not found: ${layerName}`);
+    console.error(`Available layers: ${available}`);
+    process.exit(1);
+  }
+
+  const result = await runLayer({ ...layerConfig, name: layerName }, undefined, repoRoot);
+
+  if (jsonMode) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    const status = result.pass ? 'PASS' : 'FAIL';
+    console.log(`${status} ${result.name} (${result.type})`);
+    console.log(`  Score: ${result.score}/100`);
+    console.log(`  Duration: ${result.duration_ms}ms`);
+    if (result.errors) {
+      console.log(`  Errors: ${result.errors}`);
+    }
+  }
+
+  if (!result.pass) {
+    process.exit(1);
+  }
+}
+
 function cmdLayers(): void {
   const jsonMode = args.includes('--json');
   const config = loadConfig(repoRoot);
@@ -714,6 +754,9 @@ async function main(): Promise<void> {
       break;
     case 'report':
       cmdReport();
+      break;
+    case 'layer-test':
+      await cmdLayerTest();
       break;
     case 'layers':
       cmdLayers();


### PR DESCRIPTION
Closes #76 — implemented autonomously by canductor pipeline.

Adds `canductor layer-test <name>` CLI command that runs a single verification layer in isolation using `runLayer()` from core. Shows score, pass/fail, duration, and errors. Supports `--json` output. Exits 1 on failure, shows available layers when name not found.

4 new CLI tests covering happy path, JSON output, unknown layer, and missing args.

Canductor score: 98/100 (auto_merge)

Session: https://claude.ai/code