### PR TITLE
feat: task-type tracking for self-optimizing .claude/ files

### DIFF
--- a/.claude/index.md
+++ b/.claude/index.md
@@ -57,5 +57,6 @@ Stories list which patterns and templates to follow. Patterns reference template
 | `.canductor/config.yaml` | Verification layer definitions + policy |
 | `.canductor/results.tsv` | Verification history log (scores) |
 | `.canductor/learnings.md` | What went wrong during verify and how it was fixed (narrative) |
+| `.canductor/tasks.tsv` | Per-task-type attempt tracking (maps to .claude/ files) |
 
-<!-- pipeline:index-version:2 -->
+<!-- pipeline:index-version:3 -->

--- a/.claude/skills/pipeline/SKILL.md
+++ b/.claude/skills/pipeline/SKILL.md
@@ -65,7 +65,7 @@ git diff --cached --quiet || git commit -m "chore: inject canductor quality cont
 gh issue list --repo johnnyohwishingtree/canductor --label "story" --label "pending" --state open --json number,title --jq '.[0]'
 ```
 
-If no pending stories, skip to **Step 7** (plan next epic).
+If no pending stories, skip to **Step 7** (optimize patterns).
 
 ### Step 4: Implement
 
@@ -77,11 +77,14 @@ git fetch origin master && git checkout -b canductor/issue-$NUMBER origin/master
 
 Read the issue body and implement it. The story body is your primary guide — it tells you exactly what to read and what to follow.
 
+**Parse the Tasks section** from the story body. Each task has a type in brackets like `[module]`, `[test]`, `[new-cli-command]`. These types map to `.claude/patterns/<type>.md` or `.claude/templates/<type>.md`. Track which tasks this story involves — you'll need this in Step 5 for failure attribution.
+
 **Token-efficient implementation order:**
-1. Read the story's **Context** section — these are the ONLY files you need to read. Do NOT explore the codebase beyond what's listed.
-2. Read the story's **Patterns & Templates** section — follow these INSTEAD of reverse-engineering conventions from existing code.
-3. Read the story's **Key Types** section — use these inline types instead of reading `types.ts`.
-4. If the story doesn't have these sections (older stories), fall back to reading the files listed in "Files to Create/Modify" plus the templates/patterns below.
+1. Read the story's **Tasks** section — note each task type and what it asks you to do.
+2. For each task type, read the corresponding `.claude/` file (e.g., `[module]` → read `.claude/templates/module.md`).
+3. Read the story's **Context** section — these are the ONLY additional files you need to read. Do NOT explore the codebase beyond what's listed.
+4. Read the story's **Key Types** section — use these inline types instead of reading `types.ts`.
+5. If the story doesn't have a Tasks section (older stories), fall back to reading the files listed in "Files to Create/Modify" plus the templates/patterns below.
 
 **Templates** (structure for individual files):
 - **New source modules** → `.claude/templates/module.md`
@@ -170,25 +173,44 @@ Read the decision:
 - **`auto_merge`**: proceed to Step 6.
 - **`block`** or **`human_review`**: **log what failed**, fix the issues, and loop back to the top of Step 5. This counts as your next attempt.
 
-**When verification fails, log the failure before fixing:**
+**When verification fails, log the failure with task attribution:**
+
+1. Look at the error output — which file caused the failure?
+2. Map that file back to the task (from the Tasks section) that produced it.
+3. Log both the learnings and the task result:
+
 ```bash
-# Append what went wrong to the learnings log
-# This persists across sessions — future pipeline runs read this to avoid repeating mistakes
+# Log to learnings (narrative — what went wrong and why)
 cat >> .canductor/learnings.md << LEARNING
 
 ### #$NUMBER, attempt $ATTEMPT ($(date -u +"%Y-%m-%dT%H:%M:%SZ"))
-**Failed:** <one-line summary of what the verification output said was wrong>
+**Failed:** <one-line summary of what the error said>
 LEARNING
+
+# Log to tasks.tsv (structured — which task type caused the failure)
+# task_type is from the [brackets] in the Tasks section
+# guided_by is the .claude/ file that task type maps to
+echo -e "<task_type>\t<guided_by>\t#$NUMBER\t$ATTEMPT\t<failure summary>\t$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .canductor/tasks.tsv
 ```
 
-After fixing and re-verifying successfully, record how you fixed it:
+After fixing and re-verifying successfully:
 ```bash
+# Record the fix in learnings
 cat >> .canductor/learnings.md << FIX
-**Fix:** <one-line summary of what you changed to fix it>
+**Fix:** <one-line summary of what you changed>
 FIX
+
+# Log successful task results for ALL tasks in this story
+# (each task at the passing verify cycle with failure=none)
+echo -e "<task_type>\t<guided_by>\t#$NUMBER\t$ATTEMPT\tnone\t$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> .canductor/tasks.tsv
 ```
 
-Commit the learnings file along with your code changes. The next `canductor inject CLAUDE.md` will read these learnings and surface the patterns so future sessions avoid the same mistakes.
+If `.canductor/tasks.tsv` doesn't exist yet, create it with the header first:
+```bash
+[ -f .canductor/tasks.tsv ] || echo -e "task_type\tguided_by\tref\tverify_cycle\tfailure\ttimestamp" > .canductor/tasks.tsv
+```
+
+Commit both files along with your code changes.
 
 **You have up to 6 attempts.** Each attempt: fix -> typecheck -> test -> self-review -> canductor verify with --review-json. Use the error output from each failed verify to guide your fixes.
 
@@ -227,7 +249,7 @@ Session: $SESSION_URL"
    git add .canductor/results.tsv
    git diff --cached --quiet || git commit -m "chore: log rejected result for #$NUMBER" && git push -u origin canductor/issue-$NUMBER
    ```
-5. **Stop.** Do not proceed to Step 6 or Step 7.
+5. **Stop.** Do not proceed to Step 6 or beyond.
 
 ### Step 6: Push, PR, merge, close (only if Step 5 passed)
 
@@ -274,9 +296,45 @@ git add .canductor/results.tsv
 git diff --cached --quiet || git commit -m "chore: log canductor result for #$NUMBER" && git push origin master
 ```
 
-### Step 7: Plan next epic (when queue is empty)
+### Step 7: Optimize patterns (when queue is empty)
 
-Only runs when there are no pending stories left.
+Only runs when there are no pending stories left. Analyzes task tracking data and improves the `.claude/` files that guide implementation.
+
+```bash
+PENDING=$(gh issue list --repo johnnyohwishingtree/canductor --label "story" --label "pending" --state open --json number --jq 'length')
+if [ "$PENDING" -gt 0 ]; then
+  echo "Stories still pending — skip optimization"
+  # Jump to next story instead
+fi
+```
+
+If no pending stories, check `.canductor/tasks.tsv` for task types that need optimization:
+
+1. Read `.canductor/tasks.tsv` and group by `task_type`
+2. For each task type, compute average verify cycles across all stories
+3. **Skip types with avg = 1.0 over 3+ uses** — these are converged, the pattern is good
+4. **Focus on types with avg > 1** and 3+ uses — these need pattern improvement
+5. For each optimization target:
+   a. Read the `guided_by` file (e.g., `.claude/templates/test.md`)
+   b. Read the failure reasons from the `failure` column
+   c. Update the guided_by file to explicitly address the failure patterns
+   d. Commit the change
+6. **For new task types** (appeared in tasks.tsv but no `.claude/` file exists):
+   a. Look at the successful implementation diff for that task type
+   b. Create a `.claude/patterns/<task_type>.md` capturing the approach
+   c. Commit the new pattern
+
+After updating patterns, commit and push:
+```bash
+git add .claude/
+git diff --cached --quiet || git commit -m "chore: optimize patterns based on task tracking data" && git push origin master
+```
+
+**Important:** If a previous optimization made things worse (a type's avg went UP after a pattern change), revert that specific file to its previous version using `git log` and `git checkout`.
+
+### Step 8: Plan next epic (when queue is empty)
+
+Only runs when there are no pending stories left and optimization is done.
 
 ```bash
 # Check there's truly nothing queued

--- a/.claude/templates/story.md
+++ b/.claude/templates/story.md
@@ -12,10 +12,17 @@
 - [ ] `pnpm typecheck` passes with zero errors
 - [ ] `pnpm test` passes with all tests green
 
-## Files to Create/Modify
+## Tasks
 
-- `<path/to/file.ts>` — <what changes>
-- `<path/to/file.test.ts>` — <what tests>
+Each task references the .claude/ file that guides its implementation by name.
+The pipeline tracks verify attempts per task type to optimize these files over time.
+
+1. [module] Create `<path/to/file.ts>` — <what it does>
+2. [test] Create `<path/to/file.test.ts>` — <what to test>
+3. [new-cli-command] Add command to `<path/to/cli.ts>` — <what it does>
+
+Task type names map to `.claude/patterns/<name>.md` or `.claude/templates/<name>.md`.
+If no matching file exists, the task type is new — the pipeline will create a pattern after the story ships.
 
 ## Context (read these before implementing)
 
@@ -23,15 +30,6 @@
 
 - `<path/to/file.ts>` — <why: "you're adding a function here" or "see the factory pattern on line 20">
 - `<path/to/file.ts:N-M>` — <why: "see how existing commands are structured">
-
-## Patterns & Templates
-
-<Which patterns/templates apply to this story? The implementer reads these INSTEAD of reverse-engineering conventions from existing code.>
-
-- `.claude/patterns/<relevant>.md` — <when to follow it>
-- `.claude/templates/<relevant>.md` — <which files to structure this way>
-
-If none apply, write "Standard — follow `templates/module.md` and `templates/test.md`."
 
 ## Key Types
 
@@ -53,4 +51,4 @@ None / Depends on #<number>
 
 <Any specific things canductor verify should check for this story. Leave blank if standard verification is sufficient.>
 
-<!-- canductor:story-template-version:2 -->
+<!-- canductor:story-template-version:3 -->

--- a/packages/core/__tests__/tasks.test.ts
+++ b/packages/core/__tests__/tasks.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  appendTaskResult,
+  readTaskResults,
+  analyzeTaskTypes,
+  getOptimizationTargets,
+  resolveGuidedBy,
+  summarizeTaskPerformance,
+} from '../src/tasks.js';
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'canductor-tasks-'));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('appendTaskResult', () => {
+  it('creates tasks.tsv with header on first entry', () => {
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#42', 1, '');
+
+    const content = readFileSync(join(tempDir, '.canductor/tasks.tsv'), 'utf-8');
+    expect(content).toContain('task_type\tguided_by');
+    expect(content).toContain('test\t.claude/templates/test.md\t#42\t1\tnone');
+  });
+
+  it('appends multiple entries', () => {
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#42', 1, 'vague assertions');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#42', 2, '');
+    appendTaskResult(tempDir, 'module', '.claude/templates/module.md', '#42', 1, '');
+
+    const results = readTaskResults(tempDir);
+    expect(results).toHaveLength(3);
+    expect(results[0].failure).toBe('vague assertions');
+    expect(results[1].failure).toBe('');
+    expect(results[2].task_type).toBe('module');
+  });
+});
+
+describe('readTaskResults', () => {
+  it('returns empty array when no file exists', () => {
+    expect(readTaskResults(tempDir)).toHaveLength(0);
+  });
+
+  it('parses all fields correctly', () => {
+    appendTaskResult(tempDir, 'new-cli-command', '.claude/patterns/new-cli-command.md', '#43', 2, 'wrong import path');
+
+    const results = readTaskResults(tempDir);
+    expect(results).toHaveLength(1);
+    expect(results[0].task_type).toBe('new-cli-command');
+    expect(results[0].guided_by).toBe('.claude/patterns/new-cli-command.md');
+    expect(results[0].ref).toBe('#43');
+    expect(results[0].verify_cycle).toBe(2);
+    expect(results[0].failure).toBe('wrong import path');
+    expect(results[0].timestamp).toBeTruthy();
+  });
+});
+
+describe('analyzeTaskTypes', () => {
+  it('returns empty array when no results', () => {
+    expect(analyzeTaskTypes(tempDir)).toHaveLength(0);
+  });
+
+  it('computes average cycles per task type', () => {
+    // Story #42: test took 2 cycles
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#42', 1, 'no error path');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#42', 2, '');
+    // Story #43: test took 1 cycle
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#43', 1, '');
+    // Story #44: test took 3 cycles
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#44', 1, 'wrong mock');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#44', 2, 'missing assertion');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#44', 3, '');
+
+    const analyses = analyzeTaskTypes(tempDir);
+    expect(analyses).toHaveLength(1);
+    expect(analyses[0].task_type).toBe('test');
+    expect(analyses[0].avg_cycles).toBe(2); // (2 + 1 + 3) / 3
+    expect(analyses[0].total_uses).toBe(3);
+    expect(analyses[0].total_failures).toBe(3);
+    expect(analyses[0].converged).toBe(false);
+  });
+
+  it('marks type as converged after 3 consecutive cycle-1 successes', () => {
+    appendTaskResult(tempDir, 'module', '.claude/templates/module.md', '#42', 1, '');
+    appendTaskResult(tempDir, 'module', '.claude/templates/module.md', '#43', 1, '');
+    appendTaskResult(tempDir, 'module', '.claude/templates/module.md', '#44', 1, '');
+
+    const analyses = analyzeTaskTypes(tempDir);
+    expect(analyses[0].converged).toBe(true);
+    expect(analyses[0].avg_cycles).toBe(1);
+  });
+
+  it('does not mark as converged if recent use had multiple cycles', () => {
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#42', 1, '');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#43', 1, '');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#44', 1, 'fail');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#44', 2, '');
+
+    const analyses = analyzeTaskTypes(tempDir);
+    expect(analyses[0].converged).toBe(false);
+  });
+
+  it('sorts by highest avg_cycles first', () => {
+    appendTaskResult(tempDir, 'module', '.claude/templates/module.md', '#42', 1, '');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#42', 1, 'fail');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#42', 2, 'fail');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#42', 3, '');
+
+    const analyses = analyzeTaskTypes(tempDir);
+    expect(analyses[0].task_type).toBe('test');
+    expect(analyses[1].task_type).toBe('module');
+  });
+});
+
+describe('getOptimizationTargets', () => {
+  it('returns empty when all types are at 1 cycle', () => {
+    appendTaskResult(tempDir, 'module', '.claude/templates/module.md', '#42', 1, '');
+    appendTaskResult(tempDir, 'module', '.claude/templates/module.md', '#43', 1, '');
+    appendTaskResult(tempDir, 'module', '.claude/templates/module.md', '#44', 1, '');
+
+    expect(getOptimizationTargets(tempDir)).toHaveLength(0);
+  });
+
+  it('returns types with avg > 1 and 3+ uses', () => {
+    // test: 3 uses, avg 2 cycles
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#42', 1, 'fail');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#42', 2, '');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#43', 1, 'fail');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#43', 2, '');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#44', 1, 'fail');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#44', 2, '');
+
+    // module: 3 uses, avg 1 cycle (should NOT be a target)
+    appendTaskResult(tempDir, 'module', '.claude/templates/module.md', '#42', 1, '');
+    appendTaskResult(tempDir, 'module', '.claude/templates/module.md', '#43', 1, '');
+    appendTaskResult(tempDir, 'module', '.claude/templates/module.md', '#44', 1, '');
+
+    const targets = getOptimizationTargets(tempDir);
+    expect(targets).toHaveLength(1);
+    expect(targets[0].task_type).toBe('test');
+    expect(targets[0].avg_cycles).toBe(2);
+    expect(targets[0].failures).toHaveLength(3);
+  });
+
+  it('excludes types with fewer than 3 uses', () => {
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#42', 1, 'fail');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#42', 2, '');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#43', 1, 'fail');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#43', 2, '');
+    // Only 2 uses — not enough data
+
+    expect(getOptimizationTargets(tempDir)).toHaveLength(0);
+  });
+});
+
+describe('resolveGuidedBy', () => {
+  it('finds pattern file', () => {
+    mkdirSync(join(tempDir, '.claude/patterns'), { recursive: true });
+    writeFileSync(join(tempDir, '.claude/patterns/new-cli-command.md'), '# Pattern');
+
+    expect(resolveGuidedBy(tempDir, 'new-cli-command')).toBe('.claude/patterns/new-cli-command.md');
+  });
+
+  it('finds template file', () => {
+    mkdirSync(join(tempDir, '.claude/templates'), { recursive: true });
+    writeFileSync(join(tempDir, '.claude/templates/test.md'), '# Template');
+
+    expect(resolveGuidedBy(tempDir, 'test')).toBe('.claude/templates/test.md');
+  });
+
+  it('prefers pattern over template', () => {
+    mkdirSync(join(tempDir, '.claude/patterns'), { recursive: true });
+    mkdirSync(join(tempDir, '.claude/templates'), { recursive: true });
+    writeFileSync(join(tempDir, '.claude/patterns/test.md'), '# Pattern');
+    writeFileSync(join(tempDir, '.claude/templates/test.md'), '# Template');
+
+    expect(resolveGuidedBy(tempDir, 'test')).toBe('.claude/patterns/test.md');
+  });
+
+  it('returns null when no file exists', () => {
+    expect(resolveGuidedBy(tempDir, 'nonexistent')).toBeNull();
+  });
+});
+
+describe('summarizeTaskPerformance', () => {
+  it('returns empty string when no results', () => {
+    expect(summarizeTaskPerformance(tempDir)).toBe('');
+  });
+
+  it('shows performance summary with status', () => {
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#42', 1, 'fail');
+    appendTaskResult(tempDir, 'test', '.claude/templates/test.md', '#42', 2, '');
+    appendTaskResult(tempDir, 'module', '.claude/templates/module.md', '#42', 1, '');
+
+    const summary = summarizeTaskPerformance(tempDir);
+    expect(summary).toContain('Task type performance');
+    expect(summary).toContain('test');
+    expect(summary).toContain('module');
+    expect(summary).toContain('needs work');
+    expect(summary).toContain('good');
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,8 @@ export { generateReport } from './report.js';
 export type { ReportData } from './report.js';
 export { listStaleBranches, deleteBranches } from './clean.js';
 export type { StaleBranch } from './clean.js';
+export { appendTaskResult, readTaskResults, analyzeTaskTypes, getOptimizationTargets, resolveGuidedBy, summarizeTaskPerformance } from './tasks.js';
+export type { TaskResult, TaskTypeAnalysis, OptimizationTarget } from './tasks.js';
 export type {
   CanductorConfig,
   LayerConfig,

--- a/packages/core/src/results.ts
+++ b/packages/core/src/results.ts
@@ -9,6 +9,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import type { ResultRow, VerifyResult, QualityContext, CanductorConfig, StallDetection, LayerCorrelation } from './types.js';
 import { summarizeLearnings } from './learnings.js';
+import { summarizeTaskPerformance } from './tasks.js';
 
 const RESULTS_PATH = '.canductor/results.tsv';
 const HEADER = 'ref\ttimestamp\tcomposite_score\tdecision\tlayer_scores\tstatus\tdescription';
@@ -602,6 +603,13 @@ export function generatePromptContext(repoRoot: string): string {
   const learningsSummary = summarizeLearnings(repoRoot);
   if (learningsSummary) {
     lines.push(learningsSummary);
+    lines.push('');
+  }
+
+  // Include task type performance
+  const taskSummary = summarizeTaskPerformance(repoRoot);
+  if (taskSummary) {
+    lines.push(taskSummary);
     lines.push('');
   }
 

--- a/packages/core/src/tasks.ts
+++ b/packages/core/src/tasks.ts
@@ -1,0 +1,211 @@
+/**
+ * Task tracking — tracks verify attempts per task type to optimize
+ * the .claude/ files that guide agent implementation.
+ *
+ * Each story is broken into tasks (e.g., [module], [test], [new-cli-command]).
+ * Each task type maps to a .claude/ file by name. When verification fails,
+ * the failure is attributed to the task that caused it.
+ *
+ * Over time, task types with high average attempts signal that their
+ * corresponding .claude/ file needs improvement.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+
+const TASKS_PATH = '.canductor/tasks.tsv';
+const HEADER = 'task_type\tguided_by\tref\tverify_cycle\tfailure\ttimestamp';
+
+export interface TaskResult {
+  task_type: string;
+  guided_by: string;
+  ref: string;
+  verify_cycle: number;
+  failure: string;
+  timestamp: string;
+}
+
+export interface TaskTypeAnalysis {
+  task_type: string;
+  guided_by: string;
+  total_uses: number;
+  total_failures: number;
+  avg_cycles: number;
+  recent_failures: string[];
+  converged: boolean;
+}
+
+export interface OptimizationTarget {
+  task_type: string;
+  guided_by: string;
+  avg_cycles: number;
+  total_uses: number;
+  failures: string[];
+}
+
+/** Append a task result to the TSV log. */
+export function appendTaskResult(
+  repoRoot: string,
+  taskType: string,
+  guidedBy: string,
+  ref: string,
+  verifyCycle: number,
+  failure: string,
+): void {
+  const fullPath = join(repoRoot, TASKS_PATH);
+  const dir = dirname(fullPath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+  const timestamp = new Date().toISOString();
+  const row = [taskType, guidedBy, ref, verifyCycle, failure || 'none', timestamp].join('\t');
+
+  if (!existsSync(fullPath)) {
+    writeFileSync(fullPath, HEADER + '\n' + row + '\n');
+  } else {
+    const content = readFileSync(fullPath, 'utf-8');
+    writeFileSync(fullPath, content.trimEnd() + '\n' + row + '\n');
+  }
+}
+
+/** Read all task results from the TSV log. */
+export function readTaskResults(repoRoot: string): TaskResult[] {
+  const fullPath = join(repoRoot, TASKS_PATH);
+  if (!existsSync(fullPath)) return [];
+
+  const lines = readFileSync(fullPath, 'utf-8').trim().split('\n');
+  if (lines.length <= 1) return [];
+
+  const results: TaskResult[] = [];
+  for (const line of lines.slice(1)) {
+    if (!line.trim()) continue;
+    const fields = line.split('\t');
+    if (fields.length < 6) continue;
+
+    results.push({
+      task_type: fields[0],
+      guided_by: fields[1],
+      ref: fields[2],
+      verify_cycle: parseInt(fields[3]),
+      failure: fields[4] === 'none' ? '' : fields[4],
+      timestamp: fields[5],
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Analyze task types — group results by type, compute average cycles
+ * to success, identify which types are converged vs need optimization.
+ */
+export function analyzeTaskTypes(repoRoot: string): TaskTypeAnalysis[] {
+  const results = readTaskResults(repoRoot);
+  if (results.length === 0) return [];
+
+  // Group by task_type
+  const byType = new Map<string, TaskResult[]>();
+  for (const r of results) {
+    const existing = byType.get(r.task_type) ?? [];
+    existing.push(r);
+    byType.set(r.task_type, existing);
+  }
+
+  const analyses: TaskTypeAnalysis[] = [];
+
+  for (const [taskType, typeResults] of byType) {
+    // Group by ref to count cycles per story
+    const byRef = new Map<string, TaskResult[]>();
+    for (const r of typeResults) {
+      const existing = byRef.get(r.ref) ?? [];
+      existing.push(r);
+      byRef.set(r.ref, existing);
+    }
+
+    // Max verify_cycle per ref = how many cycles that story needed for this task
+    const cyclesPerRef: number[] = [];
+    for (const refResults of byRef.values()) {
+      const maxCycle = Math.max(...refResults.map(r => r.verify_cycle));
+      cyclesPerRef.push(maxCycle);
+    }
+
+    const totalUses = cyclesPerRef.length;
+    const avgCycles = cyclesPerRef.reduce((a, b) => a + b, 0) / totalUses;
+
+    const failures = typeResults
+      .filter(r => r.failure)
+      .map(r => r.failure);
+
+    // Converged = last 3 uses all at cycle 1
+    const lastThree = cyclesPerRef.slice(-3);
+    const converged = lastThree.length >= 3 && lastThree.every(c => c === 1);
+
+    const guidedBy = typeResults[0].guided_by;
+
+    analyses.push({
+      task_type: taskType,
+      guided_by: guidedBy,
+      total_uses: totalUses,
+      total_failures: failures.length,
+      avg_cycles: Math.round(avgCycles * 10) / 10,
+      recent_failures: failures.slice(-5),
+      converged,
+    });
+  }
+
+  // Sort: highest avg_cycles first (most room for improvement)
+  analyses.sort((a, b) => b.avg_cycles - a.avg_cycles);
+  return analyses;
+}
+
+/**
+ * Get task types that need optimization: avg > 1 cycle, seen 3+ times,
+ * not yet converged.
+ */
+export function getOptimizationTargets(repoRoot: string): OptimizationTarget[] {
+  const analyses = analyzeTaskTypes(repoRoot);
+  return analyses
+    .filter(a => a.avg_cycles > 1 && a.total_uses >= 3 && !a.converged)
+    .map(a => ({
+      task_type: a.task_type,
+      guided_by: a.guided_by,
+      avg_cycles: a.avg_cycles,
+      total_uses: a.total_uses,
+      failures: a.recent_failures,
+    }));
+}
+
+/**
+ * Resolve the .claude/ file path for a task type name.
+ * Checks patterns/ first, then templates/.
+ * Returns the path if found, or null if no file exists.
+ */
+export function resolveGuidedBy(repoRoot: string, taskType: string): string | null {
+  const candidates = [
+    `.claude/patterns/${taskType}.md`,
+    `.claude/templates/${taskType}.md`,
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(join(repoRoot, candidate))) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Generate a summary of task type performance for prompt injection.
+ */
+export function summarizeTaskPerformance(repoRoot: string): string {
+  const analyses = analyzeTaskTypes(repoRoot);
+  if (analyses.length === 0) return '';
+
+  const lines: string[] = ['### Task type performance:'];
+
+  for (const a of analyses) {
+    const status = a.converged ? 'converged' : a.avg_cycles > 1 ? 'needs work' : 'good';
+    lines.push(`- **${a.task_type}** (${a.guided_by}): avg ${a.avg_cycles} cycles, ${a.total_uses} uses — ${status}`);
+    if (a.recent_failures.length > 0 && !a.converged) {
+      lines.push(`  - Recent failures: ${a.recent_failures.slice(-2).join('; ')}`);
+    }
+  }
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## The Core Loop

This is canductor's equivalent of autoresearch's val_bpb:

```
Story has tasks: [module], [test], [new-cli-command]
Each task type maps to a .claude/ file by name
Pipeline tracks verify attempts per task type
Types averaging > 1 attempt → optimize that .claude/ file
Types at 1 attempt consistently → converged, leave alone
```

The metric is **average verify cycles per task type**. Lower is better. 1.0 means the .claude/ file perfectly guides the agent. The optimization step updates the files that underperform.

## Changes

- **`packages/core/src/tasks.ts`** — tracking module (18 tests)
- **`.claude/templates/story.md`** v3 — Tasks section replaces Files + Patterns
- **`.claude/skills/pipeline/SKILL.md`** — Step 5 failure attribution, Step 7 pattern optimization, Step 8 epic planning
- **`.claude/index.md`** — documents tasks.tsv

## How It Works In Practice

```
Session 1: Story #42, tasks=[module, test, new-cli-command]
  Verify cycle 1: test failed (vague assertions)
    → Logged: test, .claude/templates/test.md, #42, 1, "vague assertions"
  Verify cycle 2: passed
    → Logged: all tasks at cycle 2 with failure=none

Session 2: Story #43, tasks=[module, test]
  Verify cycle 1: passed first try
    → Logged: all tasks at cycle 1

Queue empty → Step 7 optimization:
  test: avg 1.5 cycles, 2 uses — not enough data yet (need 3+)
  
Session N: test has 3+ uses, avg 1.8 → read .claude/templates/test.md
  → Failures: "vague assertions", "no error path"  
  → Update test.md to address these specifically
  → Next time test type appears: avg drops toward 1.0
```

329 tests passing, zero type errors.