### PR TITLE
Fix missing cmdHealth barrel export and add tests for config-check and report

### DIFF
--- a/.canductor/results.tsv
+++ b/.canductor/results.tsv
@@ -51,3 +51,4 @@ guard-ref	2026-03-23T23:13:27.937Z	38	block	typecheck:100,tests:0,code_quality:0
 133	2026-03-24T11:16:47.583Z	98	auto_merge	typecheck:100,tests:100,code_quality:93	merged	Verified 133
 137	2026-03-24T12:08:14.459Z	99	auto_merge	typecheck:100,tests:100,code_quality:96	merged	Verified 137
 138	2026-03-24T12:10:53.254Z	99	auto_merge	typecheck:100,tests:100,code_quality:97	merged	Verified 138
+142	2026-03-24T13:05:00.163Z	99	auto_merge	typecheck:100,tests:100,code_quality:95	pending	Verified 142

--- a/.canductor/tasks.tsv
+++ b/.canductor/tasks.tsv
@@ -52,3 +52,5 @@ refactor	.canductor/patterns/refactor.md	#137	1	none	2026-03-24T12:08:26Z
 module	.canductor/templates/module.md	#137	1	none	2026-03-24T12:08:26Z
 refactor	.canductor/patterns/refactor.md	#138	1	none	2026-03-24T12:11:00Z
 module	.canductor/templates/module.md	#138	1	none	2026-03-24T12:11:00Z
+module	.canductor/templates/module.md	#142	1	none	2026-03-24T13:05:07Z
+test	.canductor/templates/test.md	#142	1	none	2026-03-24T13:05:07Z

--- a/packages/cli/__tests__/cli.test.ts
+++ b/packages/cli/__tests__/cli.test.ts
@@ -990,6 +990,72 @@ describe('canductor health', () => {
   });
 });
 
+describe('canductor config-check', () => {
+  let configCheckDir: string;
+
+  beforeEach(() => {
+    configCheckDir = join(TEST_DIR, `config-check-${Date.now()}`);
+    mkdirSync(configCheckDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(configCheckDir, { recursive: true, force: true });
+  });
+
+  it('reports valid config with exit 0', () => {
+    setupConfig(configCheckDir);
+    const { stdout, exitCode } = runCli('config-check', configCheckDir);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('Config is valid');
+  });
+
+  it('reports invalid config with exit 1', () => {
+    setupConfig(configCheckDir, 'version: 999\n');
+    const { stdout, exitCode } = runCli('config-check', configCheckDir);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('ERROR');
+  });
+
+  it('outputs valid JSON with --json flag', () => {
+    setupConfig(configCheckDir);
+    const { stdout, exitCode } = runCli('config-check --json', configCheckDir);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed).toHaveProperty('valid');
+    expect(parsed).toHaveProperty('errors');
+    expect(parsed).toHaveProperty('warnings');
+  });
+});
+
+describe('canductor report', () => {
+  let reportDir: string;
+
+  beforeEach(() => {
+    reportDir = join(TEST_DIR, `report-${Date.now()}`);
+    mkdirSync(reportDir, { recursive: true });
+    setupConfig(reportDir);
+  });
+
+  afterEach(() => {
+    rmSync(reportDir, { recursive: true, force: true });
+  });
+
+  it('outputs markdown text after verification', () => {
+    runCli('verify report-test', reportDir);
+    const { stdout, exitCode } = runCli('report', reportDir);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('#');
+  });
+
+  it('outputs valid JSON with --json flag', () => {
+    runCli('verify report-json', reportDir);
+    const { stdout, exitCode } = runCli('report --json', reportDir);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed).toHaveProperty('markdown');
+  });
+});
+
 // Cleanup top-level test dir
 afterEach(() => {
   // Individual test suites clean their own dirs

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,5 +10,5 @@ export {
   cmdHistory, cmdInsights, cmdTasks, cmdReport,
   cmdInit, cmdInject, cmdSuggest, cmdContext,
   cmdResultUpdate, cmdConfigCheck, cmdClean,
-  cmdSkillLint, cmdLayers,
+  cmdSkillLint, cmdLayers, cmdHealth,
 } from './commands/index.js';


### PR DESCRIPTION
Closes #142 — implemented autonomously by canductor pipeline.

- Export `cmdHealth` from `packages/cli/src/index.ts` (was missing since #133)
- Add config-check tests: valid config, invalid config, `--json` output
- Add report tests: markdown text output, `--json` output

Canductor score: 99/100 (auto_merge)

Session: https://claude.ai/code