### PR TITLE
Add tests for clean command

### DIFF
--- a/.canductor/results.tsv
+++ b/.canductor/results.tsv
@@ -52,3 +52,4 @@ guard-ref	2026-03-23T23:13:27.937Z	38	block	typecheck:100,tests:0,code_quality:0
 137	2026-03-24T12:08:14.459Z	99	auto_merge	typecheck:100,tests:100,code_quality:96	merged	Verified 137
 138	2026-03-24T12:10:53.254Z	99	auto_merge	typecheck:100,tests:100,code_quality:97	merged	Verified 138
 142	2026-03-24T13:05:00.163Z	99	auto_merge	typecheck:100,tests:100,code_quality:95	merged	Verified 142
+143	2026-03-24T13:08:29.604Z	98	auto_merge	typecheck:100,tests:100,code_quality:93	pending	Verified 143

--- a/.canductor/tasks.tsv
+++ b/.canductor/tasks.tsv
@@ -54,3 +54,4 @@ refactor	.canductor/patterns/refactor.md	#138	1	none	2026-03-24T12:11:00Z
 module	.canductor/templates/module.md	#138	1	none	2026-03-24T12:11:00Z
 module	.canductor/templates/module.md	#142	1	none	2026-03-24T13:05:07Z
 test	.canductor/templates/test.md	#142	1	none	2026-03-24T13:05:07Z
+test	.canductor/templates/test.md	#143	1	none	2026-03-24T13:08:35Z

--- a/packages/cli/__tests__/cli.test.ts
+++ b/packages/cli/__tests__/cli.test.ts
@@ -1056,6 +1056,66 @@ describe('canductor report', () => {
   });
 });
 
+describe('canductor clean', () => {
+  let cleanDir: string;
+  let parentDir: string;
+
+  function gitInCleanDir(cmd: string): string {
+    return execSync(`git ${cmd}`, {
+      cwd: cleanDir,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  }
+
+  beforeEach(() => {
+    // Set up a bare remote + working clone (same pattern as core/clean.test.ts)
+    parentDir = join(TEST_DIR, `clean-${Date.now()}`);
+    mkdirSync(parentDir, { recursive: true });
+    const bareDir = join(parentDir, 'bare.git');
+    const workDir = join(parentDir, 'work');
+    execSync(`git init --bare ${bareDir}`, { stdio: 'pipe' });
+    execSync(`git clone ${bareDir} ${workDir}`, { stdio: 'pipe' });
+    cleanDir = workDir;
+
+    // Configure git for commits and disable signing
+    gitInCleanDir('config user.email "test@test.com"');
+    gitInCleanDir('config user.name "Test"');
+    gitInCleanDir('config commit.gpgsign false');
+    gitInCleanDir('config tag.gpgsign false');
+
+    // Create initial commit
+    execSync('touch file.txt', { cwd: cleanDir, stdio: 'pipe' });
+    gitInCleanDir('add file.txt');
+    gitInCleanDir('commit -m "initial"');
+    gitInCleanDir('push origin master');
+
+    setupConfig(cleanDir);
+  });
+
+  afterEach(() => {
+    rmSync(parentDir, { recursive: true, force: true });
+  });
+
+  it('shows no stale branches message when none exist', () => {
+    const { stdout, exitCode } = runCli('clean', cleanDir);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('No stale canductor branches');
+  });
+
+  it('lists stale branches when merged canductor branches exist', () => {
+    // Create a canductor branch (already merged — same commit as master)
+    gitInCleanDir('branch canductor/issue-999');
+    gitInCleanDir('push origin canductor/issue-999');
+    gitInCleanDir('fetch --prune');
+
+    const { stdout, exitCode } = runCli('clean', cleanDir);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('Stale branches');
+    expect(stdout).toContain('would be deleted');
+  });
+});
+
 // Cleanup top-level test dir
 afterEach(() => {
   // Individual test suites clean their own dirs


### PR DESCRIPTION
Closes #143 — implemented autonomously by canductor pipeline.

- Test no-stale-branches path (expects "No stale canductor branches")
- Test stale branch listing with bare remote + merged branch
- Uses proper git repo setup with signing disabled for test environment

Canductor score: 98/100 (auto_merge)

Session: https://claude.ai/code